### PR TITLE
Extracted Models, renamed entities to singular

### DIFF
--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -1,42 +1,9 @@
 // returns all general ledger accounts
 extern crate serde_yaml;
 
-use serde::{Deserialize, Serialize};
+use super::models::{LedgerFile};
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-struct Currencies {
-    id: String,
-    name: String,
-    alias: String,
-    note: String,
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-struct Accounts {
-    id: i32,
-    acct_name: String,
-    acct_type: String,
-    debit_credit: i32,
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-struct Transactions {
-    date: String,
-    debit_credit: i32,
-    acct_name: String,
-    acct_type: String,
-    acct_offset_name: String,
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-struct LedgerFile {
-    owner: String,
-    currencies: Currencies,
-    accounts: Vec<Accounts>,
-    transactions: Vec<Transactions>,
-}
-
-struct BalanceAccounts {
+struct BalanceAccount {
     account: String,
     account_type: String,
 }
@@ -45,10 +12,10 @@ pub fn accounts(filename: &str) -> Result<(), std::io::Error> {
     let file = std::fs::File::open(filename)?;
     let deserialized_file: LedgerFile = serde_yaml::from_reader(file).unwrap();
 
-    let mut account_vec: Vec<BalanceAccounts> = Vec::new();
+    let mut account_vec: Vec<BalanceAccount> = Vec::new();
 
     for account in deserialized_file.accounts {
-        account_vec.push(BalanceAccounts {
+        account_vec.push(BalanceAccount {
             account: account.acct_name,
             account_type: account.acct_type,
         });

--- a/src/balance.rs
+++ b/src/balance.rs
@@ -2,48 +2,15 @@
 extern crate serde_yaml;
 
 use num_format::{Locale, ToFormattedString};
-use serde::{Deserialize, Serialize};
+use super::models::{LedgerFile};
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-struct Currencies {
-    id: String,
-    name: String,
-    alias: String,
-    note: String,
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-struct Accounts {
-    id: i32,
-    acct_name: String,
-    acct_type: String,
-    debit_credit: i32,
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-struct Transactions {
-    date: String,
-    debit_credit: i32,
-    acct_name: String,
-    acct_type: String,
-    acct_offset_name: String,
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-struct LedgerFile {
-    owner: String,
-    currencies: Currencies,
-    accounts: Vec<Accounts>,
-    transactions: Vec<Transactions>,
-}
-
-struct BalanceAccounts {
+struct BalanceAccount {
     account: String,
     account_type: String,
     amount: i32,
 }
 
-struct TransactionAccounts {
+struct TransactionAccount {
     account: String,
     offset_account: String,
     amount: i32,
@@ -53,12 +20,12 @@ pub fn balance(filename: &str) -> Result<(), std::io::Error> {
     let file = std::fs::File::open(filename)?;
     let deserialized_file: LedgerFile = serde_yaml::from_reader(file).unwrap();
 
-    let mut accounts_vec: Vec<BalanceAccounts> = Vec::new();
-    let mut transactions_vec: Vec<TransactionAccounts> = Vec::new();
+    let mut accounts_vec: Vec<BalanceAccount> = Vec::new();
+    let mut transactions_vec: Vec<TransactionAccount> = Vec::new();
 
     // push opening balances into Vec
     for account in deserialized_file.accounts {
-        accounts_vec.push(BalanceAccounts {
+        accounts_vec.push(BalanceAccount {
             account: account.acct_name,
             account_type: account.acct_type,
             amount: account.debit_credit,
@@ -67,7 +34,7 @@ pub fn balance(filename: &str) -> Result<(), std::io::Error> {
 
     // push transactions into Vec
     for transaction in deserialized_file.transactions {
-        transactions_vec.push(TransactionAccounts {
+        transactions_vec.push(TransactionAccount {
             account: transaction.acct_name,
             offset_account: transaction.acct_offset_name,
             amount: transaction.debit_credit,

--- a/src/csv.rs
+++ b/src/csv.rs
@@ -3,6 +3,7 @@ extern crate csv;
 
 use serde::{Deserialize, Serialize};
 use std::{fs, io::Write};
+use super::models::{LedgerFile};
 
 #[derive(Debug, Deserialize)]
 struct CSV {
@@ -11,40 +12,6 @@ struct CSV {
     name: String,
     memo: String,
     amount: f64,
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-struct Currencies {
-    id: String,
-    name: String,
-    alias: String,
-    note: String,
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-struct Accounts {
-    id: i32,
-    acct_name: String,
-    acct_type: String,
-    debit_credit: i32,
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-struct Transactions {
-    date: String,
-    debit_credit: i32,
-    acct_name: String,
-    acct_type: String,
-    acct_offset_name: String,
-    name: String,
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-struct LedgerFile {
-    owner: String,
-    currencies: Currencies,
-    accounts: Vec<Accounts>,
-    transactions: Vec<Transactions>,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod balance;
 mod csv;
 mod error;
 mod register;
+mod models;
 
 use std::env;
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,0 +1,35 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct Currency {
+    pub id: String,
+    pub name: String,
+    pub alias: String,
+    pub note: String,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct Account {
+    pub id: i32,
+    pub acct_name: String,
+    pub acct_type: String,
+    pub debit_credit: i32,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct Transaction {
+    pub date: String,
+    pub debit_credit: i32,
+    pub acct_name: String,
+    pub acct_type: String,
+    pub acct_offset_name: String,
+    pub name: String,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct LedgerFile {
+    pub owner: String,
+    pub currencies: Currency,
+    pub accounts: Vec<Account>,
+    pub transactions: Vec<Transaction>,
+}

--- a/src/register.rs
+++ b/src/register.rs
@@ -2,41 +2,7 @@
 extern crate serde_yaml;
 
 use num_format::{Locale, ToFormattedString};
-use serde::{Deserialize, Serialize};
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-struct Currencies {
-    id: String,
-    name: String,
-    alias: String,
-    note: String,
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-struct Accounts {
-    id: i32,
-    acct_name: String,
-    acct_type: String,
-    debit_credit: i32,
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-struct Transactions {
-    date: String,
-    debit_credit: i32,
-    acct_name: String,
-    acct_type: String,
-    acct_offset_name: String,
-    name: String,
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-struct LedgerFile {
-    owner: String,
-    currencies: Currencies,
-    accounts: Vec<Accounts>,
-    transactions: Vec<Transactions>,
-}
+use super::models::{LedgerFile, Transaction};
 
 pub fn register(filename: &str, option: &str) -> Result<(), std::io::Error> {
     let file = std::fs::File::open(filename)?;
@@ -47,7 +13,7 @@ pub fn register(filename: &str, option: &str) -> Result<(), std::io::Error> {
         "date", "debit", "acct_name", "acct_offset_name", "acct_memo"
     );
 
-    let filtered_items: Vec<Transactions> = deserialized_file
+    let filtered_items: Vec<Transaction> = deserialized_file
         .transactions
         .into_iter()
         .filter(|x| {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -41,6 +41,7 @@ fn accounts_test() -> Result<(), Box<dyn std::error::Error>> {
                 acct_type: expense 
                 date: 2019-01-01
                 acct_offset_name: credit_card
+                name: 'expense transaction'
         "#;
 
     file.write_all(account_yml).unwrap();
@@ -81,6 +82,7 @@ fn balances_test() -> Result<(), Box<dyn std::error::Error>> {
                 acct_type: expense 
                 date: 2019-01-01
                 acct_offset_name: credit_card
+                name: 'expense transaction'
         "#;
 
     file.write_all(balance_yml).unwrap();


### PR DESCRIPTION
Should resolve #2; Test are passing

- Renamed models to singular for consistency. E.g Rust itself also calls a vector of strings `Vec<String>`, not `Vec<Strings>`. The same should be true for a single `Transaction` or `Vec<Transaction>`, even if we usually have many.
- There already was an inconsistency: not all declarations of `Transaction` did have the `name` field, so I had to modify two of the tests