### PR TITLE
Feature/integrate monee

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,14 @@ version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "monee"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,6 +306,7 @@ dependencies = [
  "assert_cmd 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "monee 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "pargs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "predicates 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -442,6 +451,7 @@ dependencies = [
 "checksum libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)" = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+"checksum monee 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "10185d7e26610b2ca56d56254e26b1654bbe964e7bd94be07d726f964d19d2db"
 "checksum normalize-line-endings 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 "checksum num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
 "checksum pargs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9af613895e670c4fe40d887de135a1becff72a2fc67352669bfe80ee4d650520"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ serde = { version = "1.0.110", features = ["derive"] }
 csv = "1.1.3"
 pargs = "0.1.4" 
 colored = "1.9.3"
+monee = "0.0.5"
 
 [dev-dependencies]
 assert_cmd = "1.0.1"

--- a/README.md
+++ b/README.md
@@ -141,20 +141,20 @@ general                      income
  Account                       Balance             
 ---------------------------------------
 asset
-  cash_checking                2100.00             
-  cash_savings                 2000.00             
+  cash_checking               $ 2100.00           
+  cash_savings                $ 2000.00           
 liability
-  credit_card_amex             -705.00             
+  credit_card_amex            $ -705.00           
 equity
-  equity                       -3500.00            
+  equity                      $ -3500.00          
 expense
-  grocery                      635.00              
-  general                      70.00               
+  grocery                     $ 635.00            
+  general                     $ 70.00             
 income
-  general                      -600.00             
+  general                     $ -600.00           
 
 ---------------------------------------
-check                          0
+check                         0         
 ```
 
 - register
@@ -163,17 +163,17 @@ check                          0
   - example output:
 
 ```
-Date       Description             Accounts            
--------------------------------------------------------------------------------
-11/4/2019  weekly groceries        grocery                   455.00      455.00
-                                   credit_card_amex         -455.00        0.00
-11/4/2019  raspberry pi            general                    50.00       50.00
-                                   credit_card_amex          -50.00        0.00
-05/23/2020 business stuff          cash_checking             600.00      600.00
-                                   general                  -600.00           0
-06/21/2020 grocery store           general                    20.00       20.00
-                                   grocery                   180.00      200.00
-                                   credit_card_amex         -200.00           0
+Date       Description              Accounts            
+------------------------------------------------------------------------------------------
+11/4/2019  weekly groceries         grocery                      $ 455.00         $ 455.00
+                                    credit_card_amex            $ -455.00                0
+11/4/2019  raspberry pi             general                       $ 50.00          $ 50.00
+                                    credit_card_amex             $ -50.00                0
+05/23/2020 business stuff           cash_checking                $ 600.00         $ 600.00
+                                    general                     $ -600.00                0
+06/21/2020 grocery store            general                       $ 20.00          $ 20.00
+                                    grocery                      $ 180.00         $ 200.00
+                                    credit_card_amex            $ -200.00                0
 ```
 
 - csv
@@ -188,7 +188,7 @@ Date       Description             Accounts
 - rust_ledger utilizes `yaml` files in the following format:
 
 ```yaml
-owner: user
+owner: user 
 currencies:
   id: $
   name: US Dollar
@@ -244,4 +244,15 @@ transactions:
     name: business stuff
     acct_type: income
     acct_name: general
+  - date: 06/21/2020
+    debit_credit: 200
+    acct_offset_name: credit_card_amex
+    name: grocery store
+    acct_type: expense
+    acct_name:
+    split:
+      - amount: 20
+        account: general
+      - amount: 180
+        account: grocery
 ```

--- a/src/balance.rs
+++ b/src/balance.rs
@@ -3,6 +3,8 @@ extern crate serde_yaml;
 use colored::*;
 use super::models::{LedgerFile};
 
+use monee::*;
+
 struct BalanceAccount {
     account: String,
     account_type: String,
@@ -116,11 +118,11 @@ pub fn balance(filename: &String) -> Result<(), std::io::Error> {
             "  {0: <28} {1: <20}",
             account.account,
             if account.amount < 0.0 {
-                format!("{0:.2}", account.amount).to_string().red().bold()
+                format!("{: >1}", money!(account.amount, "USD")).red().bold()
             } else if account.amount == 0.0 {
                 account.amount.to_string().yellow().bold()
             } else {
-                format!("{0:.2}", account.amount).to_string().bold()
+                format!("{: >1}", money!(account.amount, "USD")).to_string().bold()
             }
         );
     }
@@ -130,7 +132,7 @@ pub fn balance(filename: &String) -> Result<(), std::io::Error> {
     if check_figure == 0.0 {
         print!(" {:<20}\n", check_figure.to_string().bold());
     } else {
-        print!(" {:<20}\n", format!("{0:.2}", check_figure).red().bold());
+        print!(" {:<20}\n", format!("{: >1}", money!(check_figure, "USD")).red().bold());
     }
 
     println!("\n");

--- a/src/balance.rs
+++ b/src/balance.rs
@@ -22,6 +22,7 @@ struct TransactionAccount {
 pub fn balance(filename: &String) -> Result<(), std::io::Error> {
     let file = std::fs::File::open(filename)?;
     let deserialized_file: LedgerFile = serde_yaml::from_reader(file).unwrap();
+    let currency_iso = deserialized_file.currencies.alias;
 
     let mut accounts_vec: Vec<BalanceAccount> = Vec::new();
     let mut transactions_vec: Vec<TransactionAccount> = Vec::new();
@@ -116,11 +117,11 @@ pub fn balance(filename: &String) -> Result<(), std::io::Error> {
             "  {0: <27} {1: <20}",
             account.account,
             if account.amount < 0.0 {
-                format!("{: >1}", money!(account.amount, "USD")).red().bold()
+                format!("{: >1}", money!(account.amount, currency_iso)).red().bold()
             } else if account.amount == 0.0 {
                 account.amount.to_string().yellow().bold()
             } else {
-                format!("{: >1}", money!(account.amount, "USD")).to_string().bold()
+                format!("{: >1}", money!(account.amount, currency_iso)).to_string().bold()
             }
         );
     }
@@ -130,7 +131,7 @@ pub fn balance(filename: &String) -> Result<(), std::io::Error> {
     if check_figure == 0.0 {
         print!(" {:<20}\n", check_figure.to_string().bold());
     } else {
-        print!(" {:<20}\n", format!("{: >1}", money!(check_figure, "USD")).red().bold());
+        print!(" {:<20}\n", format!("{: >1}", money!(check_figure, currency_iso)).red().bold());
     }
 
     println!("\n");

--- a/src/balance.rs
+++ b/src/balance.rs
@@ -83,7 +83,6 @@ pub fn balance(filename: &String) -> Result<(), std::io::Error> {
 
     // loop over Vecs and increment(+)/decrement(-) totals
     // for each transaction
-
     for transaction in &transactions_vec {
         for account in &mut accounts_vec {
             if account.account.eq_ignore_ascii_case(&transaction.account)
@@ -97,7 +96,6 @@ pub fn balance(filename: &String) -> Result<(), std::io::Error> {
     }
 
     // create output
-
     let mut check_figure: f64 = 0.0;
 
     println!("\n {0: <29} {1: <20}", "Account".bold(), "Balance".bold());
@@ -115,7 +113,7 @@ pub fn balance(filename: &String) -> Result<(), std::io::Error> {
         }
 
         println!(
-            "  {0: <28} {1: <20}",
+            "  {0: <27} {1: <20}",
             account.account,
             if account.amount < 0.0 {
                 format!("{: >1}", money!(account.amount, "USD")).red().bold()
@@ -128,7 +126,7 @@ pub fn balance(filename: &String) -> Result<(), std::io::Error> {
     }
 
     println!("\n{:-<39}", "".bright_blue());
-    print!("{: <30}", "check");
+    print!("{: <29}", "check");
     if check_figure == 0.0 {
         print!(" {:<20}\n", check_figure.to_string().bold());
     } else {

--- a/src/register.rs
+++ b/src/register.rs
@@ -9,6 +9,7 @@ use monee::*;
 pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error> {
     let file = std::fs::File::open(filename)?;
     let deserialized_file: LedgerFile = serde_yaml::from_reader(file).unwrap();
+    let currency_iso = deserialized_file.currencies.alias;
 
     println!(
         "\n{0: <10} {1: <24} {2: <20}",
@@ -46,14 +47,14 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             item.date,
                             item.name.bold(),
                             item.acct_offset_name,
-                            format!("{: >1}", money!(item.debit_credit, "USD")).bold(),
-                            format!("{: >1}", money!(item.debit_credit, "USD")).bold()
+                            format!("{: >1}", money!(item.debit_credit, currency_iso)).bold(),
+                            format!("{: >1}", money!(item.debit_credit, currency_iso)).bold()
                         );
                         println!(
                             "{0: <36}{1: <20} {2: >16} {3: >16}",
                             "",
                             item.acct_name,
-                            format!("{: >1}", money!(-item.debit_credit, "USD")).bold(),
+                            format!("{: >1}", money!(-item.debit_credit, currency_iso)).bold(),
                             "0".bold() // hack for now. No need to do any math
                         );
                     },
@@ -62,15 +63,15 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             item.date,
                             item.name.bold(),
                             item.acct_name,
-                            format!("{: >1}", money!(item.debit_credit, "USD")).bold(),
-                            format!("{: >1}", money!(item.debit_credit, "USD")).bold()
+                            format!("{: >1}", money!(item.debit_credit, currency_iso)).bold(),
+                            format!("{: >1}", money!(item.debit_credit, currency_iso)).bold()
                         );
                         println!(
                             "{0: <36}{1: <20} {2: >16} {3: >16}",
                             "",
                             item.acct_offset_name,
-                            format!("{: >1}", money!(-item.debit_credit, "USD")).bold(),
-                            format!("{: >1}", money!(item.debit_credit - item.debit_credit, "USD")).bold()
+                            format!("{: >1}", money!(-item.debit_credit, currency_iso)).bold(),
+                            format!("{: >1}", money!(item.debit_credit - item.debit_credit, currency_iso)).bold()
                         );
                     },
                 };
@@ -83,8 +84,8 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                                 item.date,
                                 item.name.bold(),
                                 item.acct_offset_name,
-                                format!("{: >1}", money!(item.debit_credit, "USD")).bold(),
-                                format!("{: >1}", money!(item.debit_credit, "USD")).bold()
+                                format!("{: >1}", money!(item.debit_credit, currency_iso)).bold(),
+                                format!("{: >1}", money!(item.debit_credit, currency_iso)).bold()
                             );
         
                             for i in elements {
@@ -93,8 +94,8 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                                     "{0: <36}{1: <20} {2: >16} {3: >16}",
                                     "",
                                     i.account,
-                                    format!("{: >1}", money!(i.amount, "USD")).bold(),
-                                    format!("{: >1}", money!(credit, "USD)")).bold()
+                                    format!("{: >1}", money!(i.amount, currency_iso)).bold(),
+                                    format!("{: >1}", money!(credit, currency_iso)).bold()
                                 );
                             }
 
@@ -105,9 +106,9 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                                 "{0: <36}{1: <20} {2: >16} {3: >16}",
                                 "",
                                 last.account,
-                                format!("{: >1}", money!(last.amount, "USD")).bold(),
+                                format!("{: >1}", money!(last.amount, currency_iso)).bold(),
                                 if check != 0.0 { 
-                                    format!("{: >1}", money!(check, "USD")).red().bold()
+                                    format!("{: >1}", money!(check, currency_iso)).red().bold()
                                 } else { 
                                     check.to_string().bold()
                                 }
@@ -122,8 +123,8 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                                 item.date,
                                 item.name.bold(),
                                 first.account,
-                                format!("{: >1}", money!(first.amount, "USD")).bold(),
-                                format!("{: >1}", money!(first.amount, "USD")).bold()
+                                format!("{: >1}", money!(first.amount, currency_iso)).bold(),
+                                format!("{: >1}", money!(first.amount, currency_iso)).bold()
                             );
         
                             for i in elements {
@@ -132,8 +133,8 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                                     "{0: <36}{1: <20} {2: >16} {3: >16}",
                                     "",
                                     i.account,
-                                    format!("{: >1}", money!(i.amount, "USD")).bold(),
-                                    format!("{: >1}", money!(credit, "USD")).bold()
+                                    format!("{: >1}", money!(i.amount, currency_iso)).bold(),
+                                    format!("{: >1}", money!(credit, currency_iso)).bold()
                                 );
                             }
         
@@ -143,9 +144,9 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                                 "{0: <36}{1: <20} {2: >16} {3: >16}",
                                 "",
                                 item.acct_offset_name,
-                                format!("{: >1}", money!(-item.debit_credit, "USD")).bold(),
+                                format!("{: >1}", money!(-item.debit_credit, currency_iso)).bold(),
                                 if check != 0.0 {
-                                    format!("{: >1}", money!(check, "USD")).red().bold()
+                                    format!("{: >1}", money!(check, currency_iso)).red().bold()
                                 } else { 
                                     (check).to_string().bold()
                                 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -138,7 +138,7 @@ fn balances_test() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("-l").arg(file.path()).arg("balances");
     cmd.assert()
         .success()
-        .stdout(predicate::str::contains("  equity                       -1500.00"));
+        .stdout(predicate::str::contains("  equity                      $ -1500.00"));
 
     Ok(())
 }
@@ -181,7 +181,7 @@ fn register_test() -> Result<(), Box<dyn std::error::Error>> {
         .arg("register")
         .arg("-f=credit_card");
     cmd.assert().success().stdout(predicate::str::contains(
-        "2019-01-01 test memo               expense-test-acct           1.00        1.00",
+        "2019-01-01 test memo                expense-test-acct              $ 1.00           $ 1.00",
     ));
 
     Ok(())


### PR DESCRIPTION
### TLDR;

Adds back in first round of Money parsing and formatting using crate `monee`. 

### Details

`monee` is a library created by myself, dantuck, that parses numbers and formats them as money with currency based on ISO. The library is partially developed but holds the basic implementation to place the `$` and provide formatted output. Currently the format does not include commas but will in later releases.

### How to verify

Run tests

### Gif

![](https://media.giphy.com/media/Pmdw8WZGSfzUR2UVuW/source.gif)
