### PR TITLE
Schema change

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,50 +66,37 @@ OPTION (denoted by `-f`) - allows you to filter the output of the `register` com
 
 ### Features
 
-#### Transaction
+#### Transactions
 
+Transactions can be expressed in two different ways. One is a "simplified" format for transactions that only impact two accounts: 
+
+```yaml
+- date: 01/01/2020
+  amount: 200
+  offset_account: liability:credit_card_amex
+  description: grocery store
+  account: expense:expense_general
 ```
-- date: 05/23/2020
-  debit_credit: 200
-  acct_offset_name: credit_card_amex
-  name: grocery store
-  acct_type: expense
-  acct_name: expense_general
-```
 
-**Required Fields**
-* date
-* debit_credit
-* acct_offset_name
-* name
-* acct_type
-* acct_name - This field is required but can be empty
+The sign (debit / credit) associated with the `offset_account` value is the opposite of the sign of the value contained in `amount` field.  
 
-#### Split Transactions
+In the above example transaction, since `expense_general` was debited by 200, the `credit_card_amex` account will be credited by the same amount. 
 
-Each transaction can be split to multiple expense categories.
+Transactions that involve more than two accounts are expressed in the following manner:
 
-In order to add a split to a transaction add `split` to a transaction with `amount` and `account` added to each split.
-
-Splits should add up to equal the `debit_credit`.
-
-```
-- date: 05/23/2020
-  debit_credit: 200
-  acct_offset_name: credit_card_amex
-  name: grocery store
-  acct_type: expense
-  acct_name:
-  split:
+```yaml
+- date: 01/01/2020
+  description: grocery store
+  transaction:
     - amount: 20
-      account: expense_general
+      account: expense:general
     - amount: 180
-      account: expense_food
+      account: expense:grocery
+    - amount: -200
+      account: liability:credit_card_amex
 ```
 
-**Required Fields**
-* amount
-* account
+Transactions that only involve two accounts can also be expressed in the above format. 
 
 ### Test
 
@@ -122,15 +109,16 @@ Splits should add up to equal the `debit_credit`.
   - example output:
 
 ```
- Account                       Type
+ Account                      
 ---------------------------------------
-cash_checking                asset
-cash_savings                 asset
-credit_card_amex             liability
-equity                       equity
-grocery                      expense
-general                      expense
-general                      income
+asset:cash_checking         
+asset:cash_savings          
+liability:credit_card_amex  
+equity:equity               
+expense:grocery             
+expense:general             
+expense:mortgage            
+income:general   
 ```
 
 - balance
@@ -141,20 +129,21 @@ general                      income
  Account                       Balance             
 ---------------------------------------
 asset
-  cash_checking                2100.00             
-  cash_savings                 2000.00             
+  asset:cash_checking          -700.00             
+  asset:cash_savings           1000.00             
 liability
-  credit_card_amex             -705.00             
+  liability:credit_card_amex   -455.00             
 equity
-  equity                       -3500.00            
+  equity:equity                -3500.00            
 expense
-  grocery                      635.00              
-  general                      70.00               
+  expense:grocery              635.00              
+  expense:general              1020.00             
+  expense:mortgage             2000.00             
 income
-  general                      -600.00             
+  income:general               0                   
 
 ---------------------------------------
-check                          0
+check                          0          
 ```
 
 - register
@@ -165,15 +154,17 @@ check                          0
 ```
 Date       Description             Accounts            
 -------------------------------------------------------------------------------
-11/4/2019  weekly groceries        grocery                   455.00      455.00
-                                   credit_card_amex         -455.00        0.00
-11/4/2019  raspberry pi            general                    50.00       50.00
-                                   credit_card_amex          -50.00        0.00
-05/23/2020 business stuff          cash_checking             600.00      600.00
-                                   general                  -600.00           0
-06/21/2020 grocery store           general                    20.00       20.00
-                                   grocery                   180.00      200.00
-                                   credit_card_amex         -200.00           0
+11/4/2019  weekly groceries        expense:grocery           455.00      455.00
+                                   expense:grocery          -455.00       0.00
+07/04/2020 mortage                 expense:mortgage         2000.00     2000.00
+                                   expense:mortgage        -2000.00       0.00
+07/04/2020 stuff                   expense:general          1000.00     1000.00
+                                   asset:cash_savings      -1000.00        0.00
+                                                              -0.00           0
+06/21/2020 grocery store           expense:general            20.00       20.00
+                                   expense:grocery           180.00      200.00
+                                   asset:cash_checking      -200.00        0.00
+                                                              -0.00           0
 ```
 
 - csv
@@ -188,60 +179,26 @@ Date       Description             Accounts
 - rust_ledger utilizes `yaml` files in the following format:
 
 ```yaml
-owner: user
-currencies:
-  id: $
-  name: US Dollar
-  alias: USD
-  note: Currency used in the United States
-
 accounts:
-  - id: 0
-    acct_name: cash_checking
-    acct_type: asset
-    debit_credit: 1500
-  - id: 1
-    acct_name: cash_savings 
-    acct_type: asset
-    debit_credit: 2000
-  - id: 2
-    acct_name: credit_card_amex 
-    acct_type: liability
-    debit_credit: 0
-  - id: 3
-    acct_name: equity
-    acct_type: equity
-    debit_credit: -3500
-  - id: 4
-    acct_name: grocery
-    acct_type: expense
-    debit_credit: 0
-  - id: 5
-    acct_name: general
-    acct_type: expense
-    debit_credit: 0
-  - id: 6
-    acct_name: general
-    acct_type: income
-    debit_credit: 0
+  - account: 
+    amount:  
 
 transactions:
-  - date: 11/4/2019
-    debit_credit: 455
-    acct_offset_name: credit_card_amex
-    name: weekly groceries
-    acct_type: expense
-    acct_name: grocery 
-  - date: 11/4/2019
-    debit_credit: 50
-    acct_offset_name: credit_card_amex
-    name: raspberry pi
-    acct_type: expense
-    acct_name: general
-  - date: 05/23/2020
-    debit_credit: 600
-    acct_offset_name: cash_checking 
-    name: business stuff
-    acct_type: income
-    acct_name: general
+  - date: 
+    amount: 
+    description: 
+    account: 
+    offset_account: 
+  - date: 
+    description: 
+    transaction: 
+      - amount: 
+        account: 
+      - amount: 
+        account: 
 ```
+
+The ledger format schema is purposely lightweight. The only requirements are as follows:
+    - the `account` field should be expressed in the following format: `account_classification:account_name`.
+    - the `amount` field should be a number. It can include up to two (2) decimal points.  
+    - the `date` field should be in the following format: `MM-DD-YYYY`. 

--- a/examples/example.yaml
+++ b/examples/example.yaml
@@ -1,67 +1,29 @@
-owner: user 
-currencies:
-  id: $
-  name: US Dollar
-  alias: USD
-  note: Currency used in the United States
-
 accounts:
-  - id: 0
-    acct_name: cash_checking
-    acct_type: asset
-    debit_credit: 1500
-  - id: 1
-    acct_name: cash_savings 
-    acct_type: asset
-    debit_credit: 2000
-  - id: 2
-    acct_name: credit_card_amex 
-    acct_type: liability
-    debit_credit: 0
-  - id: 3
-    acct_name: equity
-    acct_type: equity
-    debit_credit: -3500
-  - id: 4
-    acct_name: grocery
-    acct_type: expense
-    debit_credit: 0
-  - id: 5
-    acct_name: general
-    acct_type: expense
-    debit_credit: 0
-  - id: 6
-    acct_name: general
-    acct_type: income
-    debit_credit: 0
+  - account: asset:cash_checking
+    amount: 1500
+  - account: asset:cash_savings 
+    amount: 2000
+  - account: liability:credit_card_amex 
+    amount: 0
+  - account: equity:equity
+    amount: -3500
+  - account: expense:grocery
+    amount: 0
+  - account: expense:general
+    amount: 0
+  - account: income:general
+    amount: 0
 
 transactions:
   - date: 11/4/2019
-    debit_credit: 455
-    acct_offset_name: credit_card_amex
-    name: weekly groceries
-    acct_type: expense
-    acct_name: grocery 
-  - date: 11/4/2019
-    debit_credit: 50
-    acct_offset_name: credit_card_amex
-    name: raspberry pi
-    acct_type: expense
-    acct_name: general
-  - date: 05/23/2020
-    debit_credit: 600
-    acct_offset_name: cash_checking 
-    name: business stuff
-    acct_type: income
-    acct_name: general
+    amount: 455
+    description: weekly groceries
+    account: expense:grocery 
+    offset_account: liability:credit_card_amex
   - date: 06/21/2020
-    debit_credit: 200
-    acct_offset_name: credit_card_amex
-    name: grocery store
-    acct_type: expense
-    acct_name:
-    split:
+    description: grocery store
+    transaction:
       - amount: 20
-        account: general
+        account: expense:general
       - amount: 180
-        account: grocery
+        account: expense:grocery

--- a/examples/example.yaml
+++ b/examples/example.yaml
@@ -22,8 +22,6 @@ transactions:
     offset_account: liability:credit_card_amex
   - date: 06/21/2020
     description: grocery store
-    account: 
-    amount: 200
     transaction:
       - amount: 20
         account: expense:general

--- a/examples/example.yaml
+++ b/examples/example.yaml
@@ -28,7 +28,6 @@ transactions:
     account: expense:mortgage
     offset_account: asset:cash_checking
   - date: 07/04/2020
-    amount: 1000
     description: stuff
     transaction: 
       - amount: 1000

--- a/examples/example.yaml
+++ b/examples/example.yaml
@@ -22,6 +22,8 @@ transactions:
     offset_account: liability:credit_card_amex
   - date: 06/21/2020
     description: grocery store
+    account: 
+    amount: 200
     transaction:
       - amount: 20
         account: expense:general

--- a/examples/example.yaml
+++ b/examples/example.yaml
@@ -1,15 +1,17 @@
 accounts:
   - account: asset:cash_checking
     amount: 1500
-  - account: asset:cash_savings 
+  - account: asset:cash_savings
     amount: 2000
-  - account: liability:credit_card_amex 
+  - account: liability:credit_card_amex
     amount: 0
   - account: equity:equity
     amount: -3500
   - account: expense:grocery
     amount: 0
   - account: expense:general
+    amount: 0
+  - account: expense:mortgage
     amount: 0
   - account: income:general
     amount: 0
@@ -18,8 +20,21 @@ transactions:
   - date: 11/4/2019
     amount: 455
     description: weekly groceries
-    account: expense:grocery 
+    account: expense:grocery
     offset_account: liability:credit_card_amex
+  - date: 07/04/2020
+    amount: 2000
+    description: mortage
+    account: expense:mortgage
+    offset_account: asset:cash_checking
+  - date: 07/04/2020
+    amount: 1000
+    description: stuff
+    transaction: 
+      - amount: 1000
+        account: expense:general
+      - amount: -1000
+        account: asset:cash_savings
   - date: 06/21/2020
     description: grocery store
     transaction:
@@ -27,3 +42,5 @@ transactions:
         account: expense:general
       - amount: 180
         account: expense:grocery
+      - amount: -200
+        account: asset:cash_checking

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -1,11 +1,10 @@
 extern crate serde_yaml;
 
-use colored::*;
 use super::models::LedgerFile;
+use colored::*;
 
 struct BalanceAccount {
     account: String,
-    account_type: String,
 }
 
 /// returns all general ledger accounts
@@ -17,19 +16,15 @@ pub fn accounts(filename: &String) -> Result<(), std::io::Error> {
 
     for account in deserialized_file.accounts {
         account_vec.push(BalanceAccount {
-            account: account.acct_name,
-            account_type: account.acct_type,
+            account: account.account,
         });
     }
 
-    println!("\n {0: <29} {1: <20}", "Account", "Type");
+    println!("\n {0: <29}", "Account");
     println!("{:-<39}", "".bright_blue());
 
     for account in account_vec {
-        println!(
-            "{0: <28} {1: <20}",
-            account.account,
-            account.account_type);
+        println!("{0: <28}", account.account);
     }
 
     println!("\n");

--- a/src/balance.rs
+++ b/src/balance.rs
@@ -60,7 +60,7 @@ pub fn balance(filename: &String) -> Result<(), std::io::Error> {
                     credit += amount;
                     transactions_vec.push(TransactionAccount {
                         account: i.account,
-                        offset_account,
+                        offset_account: offset_account.to_owned(), // TODO - value moved here, so clone it
                         amount: i.amount,
                     })
                 }
@@ -89,10 +89,10 @@ pub fn balance(filename: &String) -> Result<(), std::io::Error> {
                 account.amount += &transaction.amount;
             }
 
-            let thing = String::from("");
-
-            let transaction_offset_account: String =
-                transaction.offset_account.unwrap_or("empty".to_string());
+            let transaction_offset_account = match &transaction.offset_account {
+                Some(value) => value.to_string(),
+                None => "none".to_string(),
+            };
 
             if account
                 .account

--- a/src/balance.rs
+++ b/src/balance.rs
@@ -60,7 +60,7 @@ pub fn balance(filename: &String) -> Result<(), std::io::Error> {
                     amount,
                 });
 
-                if offset_account.is_empty() {
+                if !offset_account.is_empty() {
                     transactions_vec.push(TransactionAccount {
                         account: offset_account,
                         amount: -amount,

--- a/src/csv.rs
+++ b/src/csv.rs
@@ -8,23 +8,22 @@ use std::{fs, io::Write};
 struct CSV {
     date: String,
     transaction: String,
-    name: String,
+    description: String,
     amount: f64,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 struct CSVOutput {
     date: String,
-    debit_credit: f64,
-    acct_name: String,
-    acct_type: String,
-    acct_offset_name: String,
-    name: String,
+    amount: f64,
+    account: String,
+    offset_account: String,
+    description: String,
 }
 
 struct CSVMatches {
     acct_name: String,
-    name: String,
+    description: String,
 }
 
 fn write<T>(writer: &mut T, csv_output: &[CSVOutput]) -> Result<(), serde_yaml::Error>
@@ -48,7 +47,7 @@ fn write_ledger_file(
 
 fn insert_match_acct(csv_matches: &[CSVMatches], record: &CSV) -> String {
     for match_item in csv_matches {
-        if match_item.name == record.name {
+        if match_item.description == record.description {
             return match_item.acct_name.to_string();
         }
     }
@@ -77,10 +76,10 @@ pub fn csv(ledger_file: &String, csv_file: &String) -> Result<(), std::io::Error
 
         // loop through transactions and find matching memos
         for transaction in &deserialized_file.transactions {
-            if transaction.name.trim() == record.name.trim() {
+            if transaction.description.trim() == record.description.trim() {
                 csv_matches.push(CSVMatches {
-                    acct_name: transaction.acct_name.to_string(),
-                    name: transaction.name.trim().to_string(),
+                    acct_name: transaction.account.to_string(),
+                    description: transaction.description.trim().to_string(),
                 })
             }
         }
@@ -92,21 +91,19 @@ pub fn csv(ledger_file: &String, csv_file: &String) -> Result<(), std::io::Error
         if record.amount < 1.0 {
             csv_output.push(CSVOutput {
                 date: record.date,
-                debit_credit: -record.amount as f64,
-                acct_name: matched_acct_name,
-                acct_type: "expense".to_string(),
-                acct_offset_name: "credit_card".to_string(),
-                name: record.name.trim().to_string(),
+                amount: -record.amount as f64,
+                account: matched_acct_name,
+                offset_account: "credit_card".to_string(),
+                description: record.description.trim().to_string(),
             })
         } else {
             // if amount is positive, post as income
             csv_output.push(CSVOutput {
                 date: record.date,
-                debit_credit: record.amount as f64,
-                acct_name: matched_acct_name,
-                acct_type: "income".to_string(),
-                acct_offset_name: "credit_card".to_string(),
-                name: record.name.trim().to_string(),
+                amount: record.amount as f64,
+                account: matched_acct_name,
+                offset_account: "credit_card".to_string(),
+                description: record.description.trim().to_string(),
             })
         }
     }

--- a/src/csv.rs
+++ b/src/csv.rs
@@ -76,9 +76,14 @@ pub fn csv(ledger_file: &String, csv_file: &String) -> Result<(), std::io::Error
 
         // loop through transactions and find matching memos
         for transaction in &deserialized_file.transactions {
+            let optional_account = match &transaction.account {
+                None => "".to_string(),
+                Some(name) => name.to_string(),
+            };
+
             if transaction.description.trim() == record.description.trim() {
                 csv_matches.push(CSVMatches {
-                    acct_name: transaction.account.to_string(),
+                    acct_name: optional_account.to_string(),
                     description: transaction.description.trim().to_string(),
                 })
             }

--- a/src/models.rs
+++ b/src/models.rs
@@ -8,15 +8,15 @@ pub struct Account {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct TransactionList {
-    pub amount: f64,
     pub account: String,
+    pub amount: f64,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Transaction {
     pub date: String,
-    pub amount: f64,
     pub account: String,
+    pub amount: f64,
     pub description: String,
     pub offset_account: Option<String>,
     pub transaction: Option<Vec<TransactionList>>,

--- a/src/models.rs
+++ b/src/models.rs
@@ -15,8 +15,8 @@ pub struct TransactionList {
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Transaction {
     pub date: String,
-    pub account: String,
-    pub amount: f64,
+    pub account: Option<String>,
+    pub amount: Option<f64>,
     pub description: String,
     pub offset_account: Option<String>,
     pub transaction: Option<Vec<TransactionList>>,

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,43 +1,29 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
-pub struct Currency {
-    pub id: String,
-    pub name: String,
-    pub alias: String,
-    pub note: String,
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Account {
-    pub id: i32,
-    pub acct_name: String,
-    pub acct_type: String,
-    pub debit_credit: f64,
+    pub account: String,
+    pub amount: f64,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
-pub struct TransactionSplit {
+pub struct TransactionList {
     pub amount: f64,
     pub account: String,
-    pub account_type: Option<String>,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Transaction {
     pub date: String,
-    pub debit_credit: f64,
-    pub acct_name: String,
-    pub acct_type: String,
-    pub acct_offset_name: String,
-    pub name: String,
-    pub split: Option<Vec<TransactionSplit>>,
+    pub amount: f64,
+    pub account: String,
+    pub description: String,
+    pub offset_account: Option<String>,
+    pub transaction: Option<Vec<TransactionList>>,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct LedgerFile {
-    pub owner: String,
-    pub currencies: Currency,
     pub accounts: Vec<Account>,
     pub transactions: Vec<Transaction>,
 }

--- a/src/register.rs
+++ b/src/register.rs
@@ -1,7 +1,7 @@
 extern crate serde_yaml;
 
-use colored::*;
 use super::models::{LedgerFile, Transaction};
+use colored::*;
 
 /// returns all general ledger transactions
 pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error> {
@@ -23,12 +23,9 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
         .filter(|x| match option.as_str() {
             "all" => true,
             _ => {
-                x.acct_type.contains(option)
-                    || x.date.contains(option)
-                    || x.acct_name.contains(option)
-                    || x.acct_offset_name.contains(option)
-                    || x.name.contains(option)
-                    || x.debit_credit.to_string().contains(option)
+                x.date.contains(option)
+                    || x.description.contains(option)
+                    || x.amount.to_string().contains(option)
             }
         })
         .collect();
@@ -36,55 +33,59 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
     for item in filtered_items {
         let mut credit: f64 = 0.0;
 
-        match item.split {
+        let account_type: Vec<&str> = item.account.split(":").collect();
+
+        match item.transaction {
             None => {
-                match item.acct_type.as_ref() {
+                match account_type[0] {
                     "income" => {
-                        println!("{0: <10} {1: <20}    {2: <20}    {3: >8}    {4: >8}",
+                        println!(
+                            "{0: <10} {1: <20}    {2: <20}    {3: >8}   ",
                             item.date,
-                            item.name.bold(),
-                            item.acct_offset_name,
-                            format!("{0:.2}", item.debit_credit).to_string().bold(),
-                            format!("{0:.2}", item.debit_credit).to_string().bold()
+                            item.description.bold(),
+                            format!("{0:.2}", item.amount).to_string().bold(),
+                            format!("{0:.2}", item.amount).to_string().bold()
                         );
                         println!(
                             "{0: <35}{1: <20}    {2: >8}    {3: >8}",
                             "",
-                            item.acct_name,
-                            format!("-{0:.2}", item.debit_credit).to_string().bold(),
+                            item.account,
+                            format!("-{0:.2}", item.amount).to_string().bold(),
                             "0".bold() // hack for now. No need to do any math
                         );
-                    },
+                    }
                     _ => {
-                        println!("{0: <10} {1: <20}    {2: <20}    {3: >8}    {4: >8}",
+                        println!(
+                            "{0: <10} {1: <20}    {2: <20}    {3: >8}    {4: >8}",
                             item.date,
-                            item.name.bold(),
-                            item.acct_name,
-                            format!("{0:.2}", item.debit_credit).to_string().bold(),
-                            format!("{0:.2}", item.debit_credit).to_string().bold()
+                            item.description.bold(),
+                            item.account,
+                            format!("{0:.2}", item.amount).to_string().bold(),
+                            format!("{0:.2}", item.amount).to_string().bold()
                         );
                         println!(
-                            "{0: <35}{1: <20}    {2: >8}    {3: >8}",
+                            "{0: <35}{1: <20}    {2: >8}   ",
                             "",
-                            item.acct_offset_name,
-                            format!("-{0:.2}", item.debit_credit).to_string().bold(),
-                            format!("{0:.2}", (item.debit_credit - item.debit_credit)).to_string().bold()
+                            format!("-{0:.2}", item.amount).to_string().bold(),
+                            format!("{0:.2}", (item.amount - item.amount))
+                                .to_string()
+                                .bold()
                         );
-                    },
+                    }
                 };
-            },
+            }
             Some(split) => {
-                match item.acct_type.as_ref() {
+                match account_type[0] {
                     "income" => {
-                        if let Some((last, elements)) = split.split_last() {        
-                            println!("{0: <10} {1: <20}    {2: <20}    {3: >8}    {4: >8}",
+                        if let Some((last, elements)) = split.split_last() {
+                            println!(
+                                "{0: <10} {1: <20}    {2: <20}    {3: >8}    ",
                                 item.date,
-                                item.name.bold(),
-                                item.acct_offset_name,
-                                format!("{0:.2}", item.debit_credit).to_string().bold(),
-                                format!("{0:.2}", item.debit_credit).to_string().bold()
+                                item.description.bold(),
+                                format!("{0:.2}", item.amount).to_string().bold(),
+                                format!("{0:.2}", item.amount).to_string().bold()
                             );
-        
+
                             for i in elements {
                                 credit -= i.amount;
                                 println!(
@@ -97,33 +98,34 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             }
 
                             credit -= last.amount;
-                            let check: f64 = item.debit_credit - credit;
-        
+                            let check: f64 = item.amount - credit;
+
                             println!(
                                 "{0: <35}{1: <20}    {2: >8}    {3: >8}",
                                 "",
                                 last.account,
                                 format!("{0:.2}", last.amount).to_string().bold(),
-                                if check != 0.0 { 
+                                if check != 0.0 {
                                     format!("{0:.2}", check).to_string().red().bold()
-                                } else { 
+                                } else {
                                     check.to_string().bold()
                                 }
                             );
-                        }  
-                    },
+                        }
+                    }
                     _ => {
                         if let Some((first, elements)) = split.split_first() {
                             credit += first.amount;
-        
-                            println!("{0: <10} {1: <20}    {2: <20}    {3: >8}    {4: >8}",
+
+                            println!(
+                                "{0: <10} {1: <20}    {2: <20}    {3: >8}    {4: >8}",
                                 item.date,
-                                item.name.bold(),
+                                item.description.bold(),
                                 first.account,
                                 format!("{0:.2}", first.amount).to_string().bold(),
                                 format!("{0:.2}", first.amount).to_string().bold()
                             );
-        
+
                             for i in elements {
                                 credit += i.amount;
                                 println!(
@@ -134,23 +136,22 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                                     format!("{0:.2}", credit).to_string().bold()
                                 );
                             }
-        
-                            let check: f64 = item.debit_credit - credit;
-        
+
+                            let check: f64 = item.amount - credit;
+
                             println!(
-                                "{0: <35}{1: <20}    {2: >8}    {3: >8}",
+                                "{0: <35}{1: <20}    {2: >8}    ",
                                 "",
-                                item.acct_offset_name,
-                                format!("-{0:.2}", item.debit_credit).to_string().bold(),
+                                format!("-{0:.2}", item.amount).to_string().bold(),
                                 if check != 0.0 {
                                     (check).to_string().red().bold()
-                                } else { 
-                                    (check).to_string().bold() 
+                                } else {
+                                    (check).to_string().bold()
                                 }
                             );
-                        }  
+                        }
                     }
-                };                  
+                };
             }
         }
     }

--- a/src/register.rs
+++ b/src/register.rs
@@ -22,18 +22,24 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
         .into_iter()
         .filter(|x| match option.as_str() {
             "all" => true,
-            _ => {
-                x.date.contains(option)
-                    || x.description.contains(option)
-                    || x.amount.to_string().contains(option)
-            }
+            _ => x.date.contains(option) || x.description.contains(option),
         })
         .collect();
 
     for item in filtered_items {
+        let optional_account = match item.account {
+            None => "".to_string(),
+            Some(name) => name,
+        };
+
+        let optional_amount = match item.amount {
+            None => 0.00,
+            Some(number) => number,
+        };
+
         let mut credit: f64 = 0.0;
 
-        let account_type: Vec<&str> = item.account.split(":").collect();
+        let account_type: Vec<&str> = optional_account.split(":").collect();
 
         match item.transaction {
             None => {
@@ -43,14 +49,14 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             "{0: <10} {1: <20}    {2: <20}    {3: >8}   ",
                             item.date,
                             item.description.bold(),
-                            format!("{0:.2}", item.amount).to_string().bold(),
-                            format!("{0:.2}", item.amount).to_string().bold()
+                            format!("{0:.2}", optional_amount).to_string().bold(),
+                            format!("{0:.2}", optional_amount).to_string().bold()
                         );
                         println!(
                             "{0: <35}{1: <20}    {2: >8}    {3: >8}",
                             "",
-                            item.account,
-                            format!("-{0:.2}", item.amount).to_string().bold(),
+                            optional_account,
+                            format!("-{0:.2}", optional_amount).to_string().bold(),
                             "0".bold() // hack for now. No need to do any math
                         );
                     }
@@ -59,15 +65,15 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             "{0: <10} {1: <20}    {2: <20}    {3: >8}    {4: >8}",
                             item.date,
                             item.description.bold(),
-                            item.account,
-                            format!("{0:.2}", item.amount).to_string().bold(),
-                            format!("{0:.2}", item.amount).to_string().bold()
+                            optional_account,
+                            format!("{0:.2}", optional_amount).to_string().bold(),
+                            format!("{0:.2}", optional_amount).to_string().bold()
                         );
                         println!(
                             "{0: <35}{1: <20}    {2: >8}   ",
                             "",
-                            format!("-{0:.2}", item.amount).to_string().bold(),
-                            format!("{0:.2}", (item.amount - item.amount))
+                            format!("-{0:.2}", optional_amount).to_string().bold(),
+                            format!("{0:.2}", (optional_amount - optional_amount))
                                 .to_string()
                                 .bold()
                         );
@@ -82,8 +88,8 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                                 "{0: <10} {1: <20}    {2: <20}    {3: >8}    ",
                                 item.date,
                                 item.description.bold(),
-                                format!("{0:.2}", item.amount).to_string().bold(),
-                                format!("{0:.2}", item.amount).to_string().bold()
+                                format!("{0:.2}", optional_amount).to_string().bold(),
+                                format!("{0:.2}", optional_amount).to_string().bold()
                             );
 
                             for i in elements {
@@ -98,7 +104,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             }
 
                             credit -= last.amount;
-                            let check: f64 = item.amount - credit;
+                            let check: f64 = optional_amount - credit;
 
                             println!(
                                 "{0: <35}{1: <20}    {2: >8}    {3: >8}",
@@ -137,12 +143,12 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                                 );
                             }
 
-                            let check: f64 = item.amount - credit;
+                            let check: f64 = optional_amount - credit;
 
                             println!(
                                 "{0: <35}{1: <20}    {2: >8}    ",
                                 "",
-                                format!("-{0:.2}", item.amount).to_string().bold(),
+                                format!("-{0:.2}", optional_amount).to_string().bold(),
                                 if check != 0.0 {
                                     (check).to_string().red().bold()
                                 } else {

--- a/src/register.rs
+++ b/src/register.rs
@@ -72,7 +72,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                 match account_type[0] {
                     "income" => {
                         println!(
-                            "{0: <10} {1: <20}    {2: <20}    {3: >8}   {4: >8}",
+                            "{0: <10} {1: <20}    {2: <20}    {3: >15}   {4: >8}",
                             item.date,
                             item.description.bold(),
                             optional_offset_account,
@@ -80,7 +80,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             format!("{0:.2}", optional_amount).to_string().bold()
                         );
                         println!(
-                            "{0: <35}{1: <20}    {2: >8}    {3: >8}",
+                            "{0: <35}{1: <20}    {2: >15}    {3: >15}",
                             "",
                             optional_account,
                             format!("-{0:.2}", optional_amount).to_string().bold(),
@@ -89,7 +89,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                     }
                     _ => {
                         println!(
-                            "{0: <10} {1: <20}    {2: <20}    {3: >8}    {4: >8}",
+                            "{0: <10} {1: <20}    {2: <20}    {3: >15}    {4: >8}",
                             item.date,
                             item.description.bold(),
                             optional_account,
@@ -97,7 +97,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             format!("{0:.2}", optional_amount).to_string().bold()
                         );
                         println!(
-                            "{0: <35}{1: <20}    {2: >8}   {3: >8}",
+                            "{0: <35}{1: <20}    {2: >15}   {3: >15}",
                             "",
                             optional_offset_account,
                             format!("-{0:.2}", optional_amount).to_string().bold(),
@@ -113,7 +113,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                     "income" => {
                         if let Some((last, elements)) = split.split_last() {
                             println!(
-                                "{0: <10} {1: <20}    {2: <20}    {3: >8}    {4: >8}",
+                                "{0: <10} {1: <20}    {2: <20}    {3: >15}    {4: >8}",
                                 item.date,
                                 item.description.bold(),
                                 optional_offset_account,
@@ -124,7 +124,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             for i in elements {
                                 credit -= i.amount;
                                 println!(
-                                    "{0: <35}{1: <20}    {2: >8}    {3: >8}",
+                                    "{0: <35}{1: <20}    {2: >15}    {3: >15}",
                                     "",
                                     i.account,
                                     format!("{0:.2}", i.amount).to_string().bold(),
@@ -136,7 +136,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             let check: f64 = optional_amount - credit;
 
                             println!(
-                                "{0: <35}{1: <20}    {2: >8}    {3: >8}",
+                                "{0: <35}{1: <20}    {2: >15}    {3: >15}",
                                 "",
                                 last.account,
                                 format!("{0:.2}", last.amount).to_string().bold(),
@@ -153,7 +153,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             credit += first.amount;
 
                             println!(
-                                "{0: <10} {1: <20}    {2: <20}    {3: >8}    {4: >8}",
+                                "{0: <10} {1: <20}    {2: <20}    {3: >15}    {4: >8}",
                                 item.date,
                                 item.description.bold(),
                                 first.account,
@@ -164,7 +164,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             for i in elements {
                                 credit += i.amount;
                                 println!(
-                                    "{0: <35}{1: <20}    {2: >8}    {3: >8}",
+                                    "{0: <35}{1: <20}    {2: >15}    {3: >15}",
                                     "",
                                     i.account,
                                     format!("{0:.2}", i.amount).to_string().bold(),
@@ -175,7 +175,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             let check: f64 = optional_amount - credit;
 
                             println!(
-                                "{0: <35}{1: <20}    {2: >8}    {3: >8}",
+                                "{0: <35}{1: <20}    {2: >15}    {3: >15}",
                                 "",
                                 optional_offset_account,
                                 format!("-{0:.2}", optional_amount).to_string().bold(),

--- a/src/register.rs
+++ b/src/register.rs
@@ -24,12 +24,12 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
             "all" => true,
             _ => {
                 let optional_account = match &x.account {
-                    None => "".to_string(),
+                    None => "optional:account".to_string(),
                     Some(name) => name.to_string(),
                 };
 
                 let optional_offset_account = match &x.offset_account {
-                    None => "".to_string(),
+                    None => "optional:offset_account".to_string(),
                     Some(name) => name.to_string(),
                 };
 

--- a/src/register.rs
+++ b/src/register.rs
@@ -49,12 +49,12 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
 
     for item in filtered_items {
         let optional_account = match item.account {
-            None => "".to_string(),
+            None => "optional:account".to_string(),
             Some(name) => name,
         };
 
         let optional_offset_account = match item.offset_account {
-            None => "".to_string(),
+            None => "optional:offset_account".to_string(),
             Some(name) => name,
         };
 
@@ -65,24 +65,29 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
 
         let mut credit: f64 = 0.0;
 
-        let account_type: Vec<&str> = optional_account.split(":").collect();
+        let account_vec: Vec<&str> = optional_account.split(":").collect();
+        let account_type = account_vec[0];
+        let account_name = account_vec[1];
+
+        let offset_account_vec: Vec<&str> = optional_offset_account.split(":").collect();
+        let offset_account_name = offset_account_vec[1];
 
         match item.transaction {
             None => {
-                match account_type[0] {
+                match account_type {
                     "income" => {
                         println!(
                             "{0: <10} {1: <20}    {2: <20}    {3: >15}   {4: >8}",
                             item.date,
                             item.description.bold(),
-                            optional_offset_account,
+                            offset_account_name,
                             format!("{0:.2}", optional_amount).to_string().bold(),
                             format!("{0:.2}", optional_amount).to_string().bold()
                         );
                         println!(
                             "{0: <35}{1: <20}    {2: >8}    {3: >15}",
                             "",
-                            optional_account,
+                            account_name,
                             format!("-{0:.2}", optional_amount).to_string().bold(),
                             "0".bold() // hack for now. No need to do any math
                         );
@@ -92,14 +97,14 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             "{0: <10} {1: <20}    {2: <20}    {3: >15}    {4: >8}",
                             item.date,
                             item.description.bold(),
-                            optional_account,
+                            account_name,
                             format!("{0:.2}", optional_amount).to_string().bold(),
                             format!("{0:.2}", optional_amount).to_string().bold()
                         );
                         println!(
                             "{0: <35}{1: <20}    {2: >8}    {3: >15}",
                             "",
-                            optional_offset_account,
+                            offset_account_name,
                             format!("-{0:.2}", optional_amount).to_string().bold(),
                             format!("{0:.2}", (optional_amount - optional_amount))
                                 .to_string()
@@ -109,24 +114,26 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                 };
             }
             Some(split) => {
-                match account_type[0] {
+                match account_type {
                     "income" => {
                         if let Some((last, elements)) = split.split_last() {
                             println!(
                                 "{0: <10} {1: <20}    {2: <20}    {3: >15}    {4: >8}",
                                 item.date,
                                 item.description.bold(),
-                                optional_offset_account,
+                                offset_account_name,
                                 format!("{0:.2}", optional_amount).to_string().bold(),
                                 format!("{0:.2}", optional_amount).to_string().bold()
                             );
 
                             for i in elements {
                                 credit -= i.amount;
+                                let i_account_vec: Vec<&str> = i.account.split(":").collect();
+                                let i_account_name = i_account_vec[1];
                                 println!(
                                     "{0: <35}{1: <20}    {2: >8}    {3: >15}",
                                     "",
-                                    i.account,
+                                    i_account_name,
                                     format!("{0:.2}", i.amount).to_string().bold(),
                                     format!("{0:.2}", credit).to_string().bold()
                                 );
@@ -135,10 +142,13 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             credit -= last.amount;
                             let check: f64 = optional_amount - credit;
 
+                            let last_account_vec: Vec<&str> = last.account.split(":").collect();
+                            let last_account_name = last_account_vec[1];
+
                             println!(
                                 "{0: <35}{1: <20}    {2: >8}    {3: >15}",
                                 "",
-                                last.account,
+                                last_account_name,
                                 format!("{0:.2}", last.amount).to_string().bold(),
                                 if check != 0.0 {
                                     format!("{0:.2}", check).to_string().red().bold()
@@ -152,21 +162,26 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                         if let Some((first, elements)) = split.split_first() {
                             credit += first.amount;
 
+                            let first_account_vec: Vec<&str> = first.account.split(":").collect();
+                            let first_account_name = first_account_vec[1];
+
                             println!(
                                 "{0: <10} {1: <20}    {2: <20}    {3: >15}    {4: >8}",
                                 item.date,
                                 item.description.bold(),
-                                first.account,
+                                first_account_name,
                                 format!("{0:.2}", first.amount).to_string().bold(),
                                 format!("{0:.2}", first.amount).to_string().bold()
                             );
 
                             for i in elements {
                                 credit += i.amount;
+                                let i_account_vec: Vec<&str> = i.account.split(":").collect();
+                                let i_account_name = i_account_vec[1];
                                 println!(
                                     "{0: <35}{1: <20}    {2: >8}    {3: >15}",
                                     "",
-                                    i.account,
+                                    i_account_name,
                                     format!("{0:.2}", i.amount).to_string().bold(),
                                     format!("{0:.2}", credit).to_string().bold()
                                 );
@@ -177,7 +192,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             println!(
                                 "{0: <35}{1: <20}    {2: >8}    {3: >15}",
                                 "",
-                                optional_offset_account,
+                                offset_account_name,
                                 format!("-{0:.2}", optional_amount).to_string().bold(),
                                 if check != 0.0 {
                                     (check).to_string().red().bold()

--- a/src/register.rs
+++ b/src/register.rs
@@ -29,7 +29,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                 };
 
                 let optional_offset_account = match &x.offset_account {
-                    None => "optional:offset_account".to_string(),
+                    None => "optional:account".to_string(),
                     Some(name) => name.to_string(),
                 };
 
@@ -54,7 +54,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
         };
 
         let optional_offset_account = match item.offset_account {
-            None => "optional:offset_account".to_string(),
+            None => "optional:account".to_string(),
             Some(name) => name,
         };
 
@@ -76,8 +76,8 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
             None => {
                 match account_type {
                     "income" => {
-                        match offset_account_name {
-                            "optional:offset_account" => continue,
+                        match &optional_offset_account[..] {
+                            "optional:account" => continue,
                             _ => {
                                 println!(
                                     "{0: <10} {1: <20}    {2: <20}    {3: >8}   {4: >8}",
@@ -89,7 +89,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                                 );
                             }
                         }
-                        match account_name {
+                        match &optional_account[..] {
                             "optional:account" => continue,
                             _ => {
                                 println!(
@@ -103,7 +103,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                         }
                     }
                     _ => {
-                        match account_name {
+                        match &optional_account[..] {
                             "optional:account" => continue,
                             _ => {
                                 println!(
@@ -116,8 +116,8 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                                 );
                             }
                         }
-                        match offset_account_name {
-                            "optional:offset_account" => continue,
+                        match &optional_offset_account[..] {
+                            "optional:account" => continue,
                             _ => {
                                 println!(
                                     "{0: <35}{1: <20}    {2: >8}    {3: >8}",
@@ -137,26 +137,36 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                 match account_type {
                     "income" => {
                         if let Some((last, elements)) = split.split_last() {
-                            println!(
-                                "{0: <10} {1: <20}    {2: <20}    {3: >8}    {4: >8}",
-                                item.date,
-                                item.description.bold(),
-                                offset_account_name,
-                                format!("{0:.2}", optional_amount).to_string().bold(),
-                                format!("{0:.2}", optional_amount).to_string().bold()
-                            );
-
+                            match &optional_offset_account[..] {
+                                "optional:account" => continue,
+                                _ => {
+                                    println!(
+                                        "{0: <10} {1: <20}    {2: <20}    {3: >8}    {4: >8}",
+                                        item.date,
+                                        item.description.bold(),
+                                        offset_account_name,
+                                        format!("{0:.2}", optional_amount).to_string().bold(),
+                                        format!("{0:.2}", optional_amount).to_string().bold()
+                                    );
+                                }
+                            }
                             for i in elements {
                                 credit -= i.amount;
                                 let i_account_vec: Vec<&str> = i.account.split(":").collect();
                                 let i_account_name = i_account_vec[1];
-                                println!(
-                                    "{0: <35}{1: <20}    {2: >8}    {3: >8}",
-                                    "",
-                                    i_account_name,
-                                    format!("{0:.2}", i.amount).to_string().bold(),
-                                    format!("{0:.2}", credit).to_string().bold()
-                                );
+
+                                match &i.account[..] {
+                                    "optional:account" => continue,
+                                    _ => {
+                                        println!(
+                                            "{0: <35}{1: <20}    {2: >8}    {3: >8}",
+                                            "",
+                                            i_account_name,
+                                            format!("{0:.2}", i.amount).to_string().bold(),
+                                            format!("{0:.2}", credit).to_string().bold()
+                                        );
+                                    }
+                                }
                             }
 
                             credit -= last.amount;
@@ -165,17 +175,22 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             let last_account_vec: Vec<&str> = last.account.split(":").collect();
                             let last_account_name = last_account_vec[1];
 
-                            println!(
-                                "{0: <35}{1: <20}    {2: >8}    {3: >8}",
-                                "",
-                                last_account_name,
-                                format!("{0:.2}", last.amount).to_string().bold(),
-                                if check != 0.0 {
-                                    format!("{0:.2}", check).to_string().red().bold()
-                                } else {
-                                    check.to_string().bold()
+                            match &last.account[..] {
+                                "optional:account" => continue,
+                                _ => {
+                                    println!(
+                                        "{0: <35}{1: <20}    {2: >8}    {3: >8}",
+                                        "",
+                                        last_account_name,
+                                        format!("{0:.2}", last.amount).to_string().bold(),
+                                        if check != 0.0 {
+                                            format!("{0:.2}", check).to_string().red().bold()
+                                        } else {
+                                            check.to_string().bold()
+                                        }
+                                    );
                                 }
-                            );
+                            }
                         }
                     }
                     _ => {
@@ -185,41 +200,57 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             let first_account_vec: Vec<&str> = first.account.split(":").collect();
                             let first_account_name = first_account_vec[1];
 
-                            println!(
-                                "{0: <10} {1: <20}    {2: <20}    {3: >8}    {4: >8}",
-                                item.date,
-                                item.description.bold(),
-                                first_account_name,
-                                format!("{0:.2}", first.amount).to_string().bold(),
-                                format!("{0:.2}", first.amount).to_string().bold()
-                            );
+                            match &first.account[..] {
+                                "optional:account" => continue,
+                                _ => {
+                                    println!(
+                                        "{0: <10} {1: <20}    {2: <20}    {3: >8}    {4: >8}",
+                                        item.date,
+                                        item.description.bold(),
+                                        first_account_name,
+                                        format!("{0:.2}", first.amount).to_string().bold(),
+                                        format!("{0:.2}", first.amount).to_string().bold()
+                                    );
+                                }
+                            }
 
                             for i in elements {
                                 credit += i.amount;
                                 let i_account_vec: Vec<&str> = i.account.split(":").collect();
                                 let i_account_name = i_account_vec[1];
-                                println!(
-                                    "{0: <35}{1: <20}    {2: >8}    {3: >8}",
-                                    "",
-                                    i_account_name,
-                                    format!("{0:.2}", i.amount).to_string().bold(),
-                                    format!("{0:.2}", credit).to_string().bold()
-                                );
+
+                                match &i.account[..] {
+                                    "optional:account" => continue,
+                                    _ => {
+                                        println!(
+                                            "{0: <35}{1: <20}    {2: >8}    {3: >8}",
+                                            "",
+                                            i_account_name,
+                                            format!("{0:.2}", i.amount).to_string().bold(),
+                                            format!("{0:.2}", credit).to_string().bold()
+                                        );
+                                    }
+                                }
                             }
 
                             let check: f64 = optional_amount - credit;
 
-                            println!(
-                                "{0: <35}{1: <20}    {2: >8}    {3: >8}",
-                                "",
-                                offset_account_name,
-                                format!("-{0:.2}", optional_amount).to_string().bold(),
-                                if check != 0.0 {
-                                    (check).to_string().red().bold()
-                                } else {
-                                    (check).to_string().bold()
+                            match &optional_offset_account[..] {
+                                "optional:account" => continue,
+                                _ => {
+                                    println!(
+                                        "{0: <35}{1: <20}    {2: >8}    {3: >8}",
+                                        "",
+                                        offset_account_name,
+                                        format!("-{0:.2}", optional_amount).to_string().bold(),
+                                        if check != 0.0 {
+                                            (check).to_string().red().bold()
+                                        } else {
+                                            (check).to_string().bold()
+                                        }
+                                    );
                                 }
-                            );
+                            }
                         }
                     }
                 };

--- a/src/register.rs
+++ b/src/register.rs
@@ -80,7 +80,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             format!("{0:.2}", optional_amount).to_string().bold()
                         );
                         println!(
-                            "{0: <35}{1: <20}    {2: >15}    {3: >15}",
+                            "{0: <35}{1: <20}    {2: >8}    {3: >15}",
                             "",
                             optional_account,
                             format!("-{0:.2}", optional_amount).to_string().bold(),
@@ -97,7 +97,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             format!("{0:.2}", optional_amount).to_string().bold()
                         );
                         println!(
-                            "{0: <35}{1: <20}    {2: >15}   {3: >15}",
+                            "{0: <35}{1: <20}    {2: >8}    {3: >15}",
                             "",
                             optional_offset_account,
                             format!("-{0:.2}", optional_amount).to_string().bold(),
@@ -124,7 +124,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             for i in elements {
                                 credit -= i.amount;
                                 println!(
-                                    "{0: <35}{1: <20}    {2: >15}    {3: >15}",
+                                    "{0: <35}{1: <20}    {2: >8}    {3: >15}",
                                     "",
                                     i.account,
                                     format!("{0:.2}", i.amount).to_string().bold(),
@@ -136,7 +136,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             let check: f64 = optional_amount - credit;
 
                             println!(
-                                "{0: <35}{1: <20}    {2: >15}    {3: >15}",
+                                "{0: <35}{1: <20}    {2: >8}    {3: >15}",
                                 "",
                                 last.account,
                                 format!("{0:.2}", last.amount).to_string().bold(),
@@ -164,7 +164,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             for i in elements {
                                 credit += i.amount;
                                 println!(
-                                    "{0: <35}{1: <20}    {2: >15}    {3: >15}",
+                                    "{0: <35}{1: <20}    {2: >8}    {3: >15}",
                                     "",
                                     i.account,
                                     format!("{0:.2}", i.amount).to_string().bold(),
@@ -175,7 +175,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             let check: f64 = optional_amount - credit;
 
                             println!(
-                                "{0: <35}{1: <20}    {2: >15}    {3: >15}",
+                                "{0: <35}{1: <20}    {2: >8}    {3: >15}",
                                 "",
                                 optional_offset_account,
                                 format!("-{0:.2}", optional_amount).to_string().bold(),

--- a/src/register.rs
+++ b/src/register.rs
@@ -22,7 +22,22 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
         .into_iter()
         .filter(|x| match option.as_str() {
             "all" => true,
-            _ => x.date.contains(option) || x.description.contains(option),
+                _ => {
+
+        let optional_account = match &x.account {
+            None => "".to_string(),
+            Some(name) => name.to_string(),
+        };
+
+        let optional_amount = match x.amount {
+            None => 0.00,
+            Some(number) => number,
+        };
+                    x.date.contains(option)
+                    || optional_amount.to_string().contains(option)
+                    || optional_account.contains(option)
+                    || x.description.contains(option)
+            }
         })
         .collect();
 

--- a/src/register.rs
+++ b/src/register.rs
@@ -46,9 +46,10 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                 match account_type[0] {
                     "income" => {
                         println!(
-                            "{0: <10} {1: <20}    {2: <20}    {3: >8}   ",
+                            "{0: <10} {1: <20}    {2: <20}    {3: >8}   {4: >8}",
                             item.date,
                             item.description.bold(),
+                            optional_account,
                             format!("{0:.2}", optional_amount).to_string().bold(),
                             format!("{0:.2}", optional_amount).to_string().bold()
                         );
@@ -70,8 +71,9 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             format!("{0:.2}", optional_amount).to_string().bold()
                         );
                         println!(
-                            "{0: <35}{1: <20}    {2: >8}   ",
+                            "{0: <35}{1: <20}    {2: >8}   {3: >8}",
                             "",
+                            optional_account,
                             format!("-{0:.2}", optional_amount).to_string().bold(),
                             format!("{0:.2}", (optional_amount - optional_amount))
                                 .to_string()
@@ -85,9 +87,10 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                     "income" => {
                         if let Some((last, elements)) = split.split_last() {
                             println!(
-                                "{0: <10} {1: <20}    {2: <20}    {3: >8}    ",
+                                "{0: <10} {1: <20}    {2: <20}    {3: >8}    {4: >8}",
                                 item.date,
                                 item.description.bold(),
+                                optional_account,
                                 format!("{0:.2}", optional_amount).to_string().bold(),
                                 format!("{0:.2}", optional_amount).to_string().bold()
                             );
@@ -146,8 +149,9 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             let check: f64 = optional_amount - credit;
 
                             println!(
-                                "{0: <35}{1: <20}    {2: >8}    ",
+                                "{0: <35}{1: <20}    {2: >8}    {3: >8}",
                                 "",
+                                optional_account,
                                 format!("-{0:.2}", optional_amount).to_string().bold(),
                                 if check != 0.0 {
                                     (check).to_string().red().bold()

--- a/src/register.rs
+++ b/src/register.rs
@@ -28,6 +28,11 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                     Some(name) => name.to_string(),
                 };
 
+                let optional_offset_account = match &x.offset_account {
+                    None => "".to_string(),
+                    Some(name) => name.to_string(),
+                };
+
                 let optional_amount = match x.amount {
                     None => 0.00,
                     Some(number) => number,
@@ -36,6 +41,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                 x.date.contains(option)
                     || optional_amount.to_string().contains(option)
                     || optional_account.contains(option)
+                    || optional_offset_account.contains(option)
                     || x.description.contains(option)
             }
         })
@@ -43,6 +49,11 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
 
     for item in filtered_items {
         let optional_account = match item.account {
+            None => "".to_string(),
+            Some(name) => name,
+        };
+
+        let optional_offset_account = match item.offset_account {
             None => "".to_string(),
             Some(name) => name,
         };
@@ -64,7 +75,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             "{0: <10} {1: <20}    {2: <20}    {3: >8}   {4: >8}",
                             item.date,
                             item.description.bold(),
-                            optional_account,
+                            optional_offset_account,
                             format!("{0:.2}", optional_amount).to_string().bold(),
                             format!("{0:.2}", optional_amount).to_string().bold()
                         );
@@ -88,7 +99,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                         println!(
                             "{0: <35}{1: <20}    {2: >8}   {3: >8}",
                             "",
-                            optional_account,
+                            optional_offset_account,
                             format!("-{0:.2}", optional_amount).to_string().bold(),
                             format!("{0:.2}", (optional_amount - optional_amount))
                                 .to_string()
@@ -105,7 +116,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                                 "{0: <10} {1: <20}    {2: <20}    {3: >8}    {4: >8}",
                                 item.date,
                                 item.description.bold(),
-                                optional_account,
+                                optional_offset_account,
                                 format!("{0:.2}", optional_amount).to_string().bold(),
                                 format!("{0:.2}", optional_amount).to_string().bold()
                             );
@@ -166,7 +177,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             println!(
                                 "{0: <35}{1: <20}    {2: >8}    {3: >8}",
                                 "",
-                                optional_account,
+                                optional_offset_account,
                                 format!("-{0:.2}", optional_amount).to_string().bold(),
                                 if check != 0.0 {
                                     (check).to_string().red().bold()

--- a/src/register.rs
+++ b/src/register.rs
@@ -22,18 +22,18 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
         .into_iter()
         .filter(|x| match option.as_str() {
             "all" => true,
-                _ => {
+            _ => {
+                let optional_account = match &x.account {
+                    None => "".to_string(),
+                    Some(name) => name.to_string(),
+                };
 
-        let optional_account = match &x.account {
-            None => "".to_string(),
-            Some(name) => name.to_string(),
-        };
+                let optional_amount = match x.amount {
+                    None => 0.00,
+                    Some(number) => number,
+                };
 
-        let optional_amount = match x.amount {
-            None => 0.00,
-            Some(number) => number,
-        };
-                    x.date.contains(option)
+                x.date.contains(option)
                     || optional_amount.to_string().contains(option)
                     || optional_account.contains(option)
                     || x.description.contains(option)

--- a/src/register.rs
+++ b/src/register.rs
@@ -76,40 +76,60 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
             None => {
                 match account_type {
                     "income" => {
-                        println!(
-                            "{0: <10} {1: <20}    {2: <20}    {3: >8}   {4: >8}",
-                            item.date,
-                            item.description.bold(),
-                            offset_account_name,
-                            format!("{0:.2}", optional_amount).to_string().bold(),
-                            format!("{0:.2}", optional_amount).to_string().bold()
-                        );
-                        println!(
-                            "{0: <35}{1: <20}    {2: >8}    {3: >8}",
-                            "",
-                            account_name,
-                            format!("-{0:.2}", optional_amount).to_string().bold(),
-                            "0".bold() // hack for now. No need to do any math
-                        );
+                        match offset_account_name {
+                            "optional:offset_account" => continue,
+                            _ => {
+                                println!(
+                                    "{0: <10} {1: <20}    {2: <20}    {3: >8}   {4: >8}",
+                                    item.date,
+                                    item.description.bold(),
+                                    offset_account_name,
+                                    format!("{0:.2}", optional_amount).to_string().bold(),
+                                    format!("{0:.2}", optional_amount).to_string().bold()
+                                );
+                            }
+                        }
+                        match account_name {
+                            "optional:account" => continue,
+                            _ => {
+                                println!(
+                                    "{0: <35}{1: <20}    {2: >8}    {3: >8}",
+                                    "",
+                                    account_name,
+                                    format!("-{0:.2}", optional_amount).to_string().bold(),
+                                    "0".bold() // hack for now. No need to do any math
+                                );
+                            }
+                        }
                     }
                     _ => {
-                        println!(
-                            "{0: <10} {1: <20}    {2: <20}    {3: >8}    {4: >8}",
-                            item.date,
-                            item.description.bold(),
-                            account_name,
-                            format!("{0:.2}", optional_amount).to_string().bold(),
-                            format!("{0:.2}", optional_amount).to_string().bold()
-                        );
-                        println!(
-                            "{0: <35}{1: <20}    {2: >8}    {3: >8}",
-                            "",
-                            offset_account_name,
-                            format!("-{0:.2}", optional_amount).to_string().bold(),
-                            format!("{0:.2}", (optional_amount - optional_amount))
-                                .to_string()
-                                .bold()
-                        );
+                        match account_name {
+                            "optional:account" => continue,
+                            _ => {
+                                println!(
+                                    "{0: <10} {1: <20}    {2: <20}    {3: >8}    {4: >8}",
+                                    item.date,
+                                    item.description.bold(),
+                                    account_name,
+                                    format!("{0:.2}", optional_amount).to_string().bold(),
+                                    format!("{0:.2}", optional_amount).to_string().bold()
+                                );
+                            }
+                        }
+                        match offset_account_name {
+                            "optional:offset_account" => continue,
+                            _ => {
+                                println!(
+                                    "{0: <35}{1: <20}    {2: >8}    {3: >8}",
+                                    "",
+                                    offset_account_name,
+                                    format!("-{0:.2}", optional_amount).to_string().bold(),
+                                    format!("{0:.2}", (optional_amount - optional_amount))
+                                        .to_string()
+                                        .bold()
+                                );
+                            }
+                        }
                     }
                 };
             }

--- a/src/register.rs
+++ b/src/register.rs
@@ -77,7 +77,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                 match account_type {
                     "income" => {
                         println!(
-                            "{0: <10} {1: <20}    {2: <20}    {3: >15}   {4: >8}",
+                            "{0: <10} {1: <20}    {2: <20}    {3: >8}   {4: >8}",
                             item.date,
                             item.description.bold(),
                             offset_account_name,
@@ -85,7 +85,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             format!("{0:.2}", optional_amount).to_string().bold()
                         );
                         println!(
-                            "{0: <35}{1: <20}    {2: >8}    {3: >15}",
+                            "{0: <35}{1: <20}    {2: >8}    {3: >8}",
                             "",
                             account_name,
                             format!("-{0:.2}", optional_amount).to_string().bold(),
@@ -94,7 +94,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                     }
                     _ => {
                         println!(
-                            "{0: <10} {1: <20}    {2: <20}    {3: >15}    {4: >8}",
+                            "{0: <10} {1: <20}    {2: <20}    {3: >8}    {4: >8}",
                             item.date,
                             item.description.bold(),
                             account_name,
@@ -102,7 +102,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             format!("{0:.2}", optional_amount).to_string().bold()
                         );
                         println!(
-                            "{0: <35}{1: <20}    {2: >8}    {3: >15}",
+                            "{0: <35}{1: <20}    {2: >8}    {3: >8}",
                             "",
                             offset_account_name,
                             format!("-{0:.2}", optional_amount).to_string().bold(),
@@ -118,7 +118,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                     "income" => {
                         if let Some((last, elements)) = split.split_last() {
                             println!(
-                                "{0: <10} {1: <20}    {2: <20}    {3: >15}    {4: >8}",
+                                "{0: <10} {1: <20}    {2: <20}    {3: >8}    {4: >8}",
                                 item.date,
                                 item.description.bold(),
                                 offset_account_name,
@@ -131,7 +131,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                                 let i_account_vec: Vec<&str> = i.account.split(":").collect();
                                 let i_account_name = i_account_vec[1];
                                 println!(
-                                    "{0: <35}{1: <20}    {2: >8}    {3: >15}",
+                                    "{0: <35}{1: <20}    {2: >8}    {3: >8}",
                                     "",
                                     i_account_name,
                                     format!("{0:.2}", i.amount).to_string().bold(),
@@ -146,7 +146,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             let last_account_name = last_account_vec[1];
 
                             println!(
-                                "{0: <35}{1: <20}    {2: >8}    {3: >15}",
+                                "{0: <35}{1: <20}    {2: >8}    {3: >8}",
                                 "",
                                 last_account_name,
                                 format!("{0:.2}", last.amount).to_string().bold(),
@@ -166,7 +166,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             let first_account_name = first_account_vec[1];
 
                             println!(
-                                "{0: <10} {1: <20}    {2: <20}    {3: >15}    {4: >8}",
+                                "{0: <10} {1: <20}    {2: <20}    {3: >8}    {4: >8}",
                                 item.date,
                                 item.description.bold(),
                                 first_account_name,
@@ -179,7 +179,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                                 let i_account_vec: Vec<&str> = i.account.split(":").collect();
                                 let i_account_name = i_account_vec[1];
                                 println!(
-                                    "{0: <35}{1: <20}    {2: >8}    {3: >15}",
+                                    "{0: <35}{1: <20}    {2: >8}    {3: >8}",
                                     "",
                                     i_account_name,
                                     format!("{0:.2}", i.amount).to_string().bold(),
@@ -190,7 +190,7 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             let check: f64 = optional_amount - credit;
 
                             println!(
-                                "{0: <35}{1: <20}    {2: >8}    {3: >15}",
+                                "{0: <35}{1: <20}    {2: >8}    {3: >8}",
                                 "",
                                 offset_account_name,
                                 format!("-{0:.2}", optional_amount).to_string().bold(),


### PR DESCRIPTION
Changes:
 - Refactors each module and related integration tests to utilize a new YAML schema. A populated example of this new schema is as follows:
```yaml
accounts:
  - account: asset:cash_checking
    amount: 1500
  - account: asset:cash_savings
    amount: 2000
  - account: liability:credit_card_amex
    amount: 0
  - account: equity:equity
    amount: -3500
  - account: expense:grocery
    amount: 0
  - account: expense:general
    amount: 0
  - account: expense:mortgage
    amount: 0
  - account: income:general
    amount: 0

transactions:
  - date: 11/4/2019
    amount: 455
    description: weekly groceries
    account: expense:grocery
    offset_account: liability:credit_card_amex
  - date: 07/04/2020
    amount: 2000
    description: mortage
    account: expense:mortgage
    offset_account: asset:cash_checking
  - date: 07/04/2020
    description: stuff
    transaction: 
      - amount: 1000
        account: expense:general
      - amount: -1000
        account: asset:cash_savings
  - date: 06/21/2020
    description: grocery store
    transaction:
      - amount: 20
        account: expense:general
      - amount: 180
        account: expense:grocery
      - amount: -200
        account: asset:cash_checking
```
Compared to the original schema, the new schema includes less fields and therefore significantly improves readability and reduces redundancy. 

- Further, `transactions` are more flexible and declarative. Transactions that only involve two accounts (a debit and an offsetting credit, or vice-versa) can be expressed in a short-hand method:
```yaml
  - date: 11/4/2019
    amount: 455
    description: weekly groceries
    account: expense:grocery
    offset_account: liability:credit_card_amex
```
Alternatively, the transaction postings can be specified in detail:
```yaml
  - date: 11/4/2019
    description: weekly groceries
    transaction: 
      - amount: 455
        account: expense:groceries
      - amount: -455
        account: liability:credit_card_amex
```
`rust_ledger` treats both of the above transactions in the same manner. This allows the user more flexibility in expressing transactions in their individual YAML file.

`transactions` that involve more than two accounts would need to use the second format.