### PR TITLE
Added monee to register and balance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,14 @@ version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "monee"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,6 +306,7 @@ dependencies = [
  "assert_cmd 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "monee 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "pargs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "predicates 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -442,6 +451,7 @@ dependencies = [
 "checksum libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)" = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+"checksum monee 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "10185d7e26610b2ca56d56254e26b1654bbe964e7bd94be07d726f964d19d2db"
 "checksum normalize-line-endings 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 "checksum num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
 "checksum pargs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9af613895e670c4fe40d887de135a1becff72a2fc67352669bfe80ee4d650520"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ serde = { version = "1.0.110", features = ["derive"] }
 csv = "1.1.3"
 pargs = "0.1.4" 
 colored = "1.9.3"
+monee = "0.0.5"
 
 [dev-dependencies]
 assert_cmd = "1.0.1"

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ equity:equity
 expense:grocery             
 expense:general             
 expense:mortgage            
-income:general   
+income:general
 ```
 
 - balance
@@ -129,21 +129,21 @@ income:general
  Account                       Balance             
 ---------------------------------------
 asset
-  asset:cash_checking          -700.00             
-  asset:cash_savings           1000.00             
+  asset:cash_checking          $ -700.00           
+  asset:cash_savings           $ 1000.00           
 liability
-  liability:credit_card_amex   -455.00             
+  liability:credit_card_amex   $ -455.00           
 equity
-  equity:equity                -3500.00            
+  equity:equity                $ -3500.00          
 expense
-  expense:grocery              635.00              
-  expense:general              1020.00             
-  expense:mortgage             2000.00             
+  expense:grocery              $ 635.00            
+  expense:general              $ 1020.00           
+  expense:mortgage             $ 2000.00           
 income
   income:general               0                   
 
 ---------------------------------------
-check                          0          
+check                          0           
 ```
 
 - register
@@ -152,17 +152,17 @@ check                          0
   - example output:
 
 ```
-Date       Description             Accounts            
--------------------------------------------------------------------------------
-11/4/2019  weekly groceries        expense:grocery           455.00      455.00
-                                   expense:grocery          -455.00       0.00
-07/04/2020 mortage                 expense:mortgage         2000.00     2000.00
-                                   expense:mortgage        -2000.00       0.00
-07/04/2020 stuff                   expense:general          1000.00     1000.00
-                                   asset:cash_savings      -1000.00        0.00
-06/21/2020 grocery store           expense:general            20.00       20.00
-                                   expense:grocery           180.00      200.00
-                                   asset:cash_checking      -200.00        0.00
+Date       Description             Accounts              
+---------------------------------------------------------------------------------
+11/4/2019  weekly groceries        grocery                  $ 455.00     $ 455.00
+                                   credit_card_amex        $ -455.00            0
+07/04/2020 mortage                 mortgage                $ 2000.00    $ 2000.00
+                                   cash_checking          $ -2000.00            0
+07/04/2020 stuff                   general                 $ 1000.00    $ 1000.00
+                                   cash_savings           $ -1000.00            0
+06/21/2020 grocery store           general                   $ 20.00      $ 20.00
+                                   grocery                  $ 180.00     $ 200.00
+                                   cash_checking           $ -200.00            0
 ```
 
 - csv

--- a/src/balance.rs
+++ b/src/balance.rs
@@ -2,6 +2,7 @@ extern crate serde_yaml;
 
 use super::models::LedgerFile;
 use colored::*;
+use monee::*;
 
 struct BalanceAccount {
     account: String,
@@ -130,11 +131,11 @@ pub fn balance(filename: &String) -> Result<(), std::io::Error> {
             "  {0: <28} {1: <20}",
             account.account,
             if account.amount < 0.0 {
-                format!("{0:.2}", account.amount).to_string().red().bold()
+                format!("{: >1}", money!(account.amount, "USD")).to_string().red().bold()
             } else if account.amount == 0.0 {
                 account.amount.to_string().yellow().bold()
             } else {
-                format!("{0:.2}", account.amount).to_string().bold()
+                format!("{: >1}", money!(account.amount, "USD")).to_string().bold()
             }
         );
     }

--- a/src/register.rs
+++ b/src/register.rs
@@ -2,6 +2,7 @@ extern crate serde_yaml;
 
 use super::models::{LedgerFile, Transaction};
 use colored::*;
+use monee::*;
 
 /// returns all general ledger transactions
 pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error> {
@@ -9,13 +10,13 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
     let deserialized_file: LedgerFile = serde_yaml::from_reader(file).unwrap();
 
     println!(
-        "\n{0: <10} {1: <23} {2: <20}",
+        "\n{0: <10} {1: <23} {2: <22}",
         "Date".bold(),
         "Description".bold(),
         "Accounts".bold()
     );
 
-    println!("{0:-<79}", "".bright_blue());
+    println!("{0:-<81}", "".bright_blue());
 
     let filtered_items: Vec<Transaction> = deserialized_file
         .transactions
@@ -80,12 +81,12 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             "optional:account" => continue,
                             _ => {
                                 println!(
-                                    "{0: <10} {1: <20}    {2: <20}    {3: >8}   {4: >8}",
+                                    "{0: <10} {1: <23} {2: <20} {3: >12} {4: >12}",
                                     item.date,
                                     item.description.bold(),
                                     offset_account_name,
-                                    format!("{0:.2}", optional_amount).to_string().bold(),
-                                    format!("{0:.2}", optional_amount).to_string().bold()
+                                    format!("{: >1}", money!(optional_amount, "USD")).to_string().bold(),
+                                    format!("{: >1}", money!(optional_amount, "USD")).to_string().bold()
                                 );
                             }
                         }
@@ -93,10 +94,10 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             "optional:account" => continue,
                             _ => {
                                 println!(
-                                    "{0: <35}{1: <20}    {2: >8}    {3: >8}",
+                                    "{0: <35}{1: <20} {2: >12} {3: >12}",
                                     "",
                                     account_name,
-                                    format!("-{0:.2}", optional_amount).to_string().bold(),
+                                    format!("{: >1}", money!(-optional_amount, "USD")).to_string().bold(),
                                     "0".bold() // hack for now. No need to do any math
                                 );
                             }
@@ -107,12 +108,12 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             "optional:account" => continue,
                             _ => {
                                 println!(
-                                    "{0: <10} {1: <20}    {2: <20}    {3: >8}    {4: >8}",
+                                    "{0: <10} {1: <23} {2: <20} {3: >12} {4: >12}",
                                     item.date,
                                     item.description.bold(),
                                     account_name,
-                                    format!("{0:.2}", optional_amount).to_string().bold(),
-                                    format!("{0:.2}", optional_amount).to_string().bold()
+                                    format!("{: >1}", money!(optional_amount, "USD")).to_string().bold(),
+                                    format!("{: >1}", money!(optional_amount, "USD")).to_string().bold()
                                 );
                             }
                         }
@@ -120,11 +121,11 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                             "optional:account" => continue,
                             _ => {
                                 println!(
-                                    "{0: <35}{1: <20}    {2: >8}    {3: >8}",
+                                    "{0: <35}{1: <20} {2: >12} {3: >12}",
                                     "",
                                     offset_account_name,
-                                    format!("-{0:.2}", optional_amount).to_string().bold(),
-                                    format!("{0:.2}", (optional_amount - optional_amount))
+                                    format!("{: >1}", money!(-optional_amount, "USD")).to_string().bold(),
+                                    format!("{: >1}", money!((optional_amount - optional_amount), "USD"))
                                         .to_string()
                                         .bold()
                                 );
@@ -141,12 +142,12 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                                 "optional:account" => continue,
                                 _ => {
                                     println!(
-                                        "{0: <10} {1: <20}    {2: <20}    {3: >8}    {4: >8}",
+                                        "{0: <10} {1: <23} {2: <20} {3: >12} {4: >12}",
                                         item.date,
                                         item.description.bold(),
                                         offset_account_name,
-                                        format!("{0:.2}", optional_amount).to_string().bold(),
-                                        format!("{0:.2}", optional_amount).to_string().bold()
+                                        format!("{: >1}", money!(optional_amount, "USD")).to_string().bold(),
+                                        format!("{: >1}", money!(optional_amount, "USD")).to_string().bold()
                                     );
                                 }
                             }
@@ -159,11 +160,11 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                                     "optional:account" => continue,
                                     _ => {
                                         println!(
-                                            "{0: <35}{1: <20}    {2: >8}    {3: >8}",
+                                            "{0: <35}{1: <20} {2: >12} {3: >12}",
                                             "",
                                             i_account_name,
-                                            format!("{0:.2}", i.amount).to_string().bold(),
-                                            format!("{0:.2}", credit).to_string().bold()
+                                            format!("{: >1}", money!(i.amount, "USD")).to_string().bold(),
+                                            format!("{: >1}", money!(credit, "USD")).to_string().bold()
                                         );
                                     }
                                 }
@@ -179,12 +180,12 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                                 "optional:account" => continue,
                                 _ => {
                                     println!(
-                                        "{0: <35}{1: <20}    {2: >8}    {3: >8}",
+                                        "{0: <35}{1: <20} {2: >12} {3: >12}",
                                         "",
                                         last_account_name,
-                                        format!("{0:.2}", last.amount).to_string().bold(),
+                                        format!("{: >1}", money!(last.amount, "USD")).to_string().bold(),
                                         if check != 0.0 {
-                                            format!("{0:.2}", check).to_string().red().bold()
+                                            format!("{: >1}", money!(check, "USD")).to_string().red().bold()
                                         } else {
                                             check.to_string().bold()
                                         }
@@ -204,12 +205,12 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                                 "optional:account" => continue,
                                 _ => {
                                     println!(
-                                        "{0: <10} {1: <20}    {2: <20}    {3: >8}    {4: >8}",
+                                        "{0: <10} {1: <23} {2: <20} {3: >12} {4: >12}",
                                         item.date,
                                         item.description.bold(),
                                         first_account_name,
-                                        format!("{0:.2}", first.amount).to_string().bold(),
-                                        format!("{0:.2}", first.amount).to_string().bold()
+                                        format!("{: >1}", money!(first.amount, "USD")).to_string().bold(),
+                                        format!("{: >1}", money!(first.amount, "USD")).to_string().bold()
                                     );
                                 }
                             }
@@ -223,11 +224,11 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                                     "optional:account" => continue,
                                     _ => {
                                         println!(
-                                            "{0: <35}{1: <20}    {2: >8}    {3: >8}",
+                                            "{0: <35}{1: <20} {2: >12} {3: >12}",
                                             "",
                                             i_account_name,
-                                            format!("{0:.2}", i.amount).to_string().bold(),
-                                            format!("{0:.2}", credit).to_string().bold()
+                                            format!("{: >1}", money!(i.amount, "USD")).to_string().bold(),
+                                            format!("{: >1}", money!(credit, "USD")).to_string().bold()
                                         );
                                     }
                                 }
@@ -239,10 +240,10 @@ pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error
                                 "optional:account" => continue,
                                 _ => {
                                     println!(
-                                        "{0: <35}{1: <20}    {2: >8}    {3: >8}",
+                                        "{0: <35}{1: <20} {2: >12} {3: >12}",
                                         "",
                                         offset_account_name,
-                                        format!("-{0:.2}", optional_amount).to_string().bold(),
+                                        format!("{: >1}", money!(-optional_amount, "USD")).to_string().bold(),
                                         if check != 0.0 {
                                             (check).to_string().red().bold()
                                         } else {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -161,7 +161,7 @@ fn balances_test() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("-l").arg(file.path()).arg("balances");
     cmd.assert()
         .success()
-        .stdout(predicate::str::contains("equity:equity                -3500.00 "));
+        .stdout(predicate::str::contains("equity:equity                $ -3500.00 "));
 
     Ok(())
 }


### PR DESCRIPTION
### TLDR;

Adds back in first round of Money parsing and formatting using crate `monee`. 

### Details

`monee` is a library created by myself, dantuck, that parses numbers and formats them as money with currency based on ISO. The library is partially developed but holds the basic implementation to place the `$` and provide formatted output. Currently the format does not include commas but will in later releases.

### How to verify

Run tests