### PR TITLE
Improve error handling

### DIFF
--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -1,7 +1,7 @@
 extern crate serde_yaml;
 
 use super::models::LedgerFile;
-use crate::error::LedgerError;
+use crate::ledger_error::LedgerError;
 use colored::*;
 
 struct BalanceAccount {

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -1,6 +1,7 @@
 extern crate serde_yaml;
 
 use super::models::LedgerFile;
+use crate::error::LedgerError;
 use colored::*;
 
 struct BalanceAccount {
@@ -8,7 +9,7 @@ struct BalanceAccount {
 }
 
 /// returns all general ledger accounts
-pub fn accounts(filename: &String) -> Result<(), std::io::Error> {
+pub fn accounts(filename: &String) -> Result<(), LedgerError> {
     let file = std::fs::File::open(filename)?;
     let deserialized_file: LedgerFile = serde_yaml::from_reader(file).unwrap();
 

--- a/src/balance.rs
+++ b/src/balance.rs
@@ -1,7 +1,7 @@
 extern crate serde_yaml;
 
 use super::models::LedgerFile;
-use crate::error::LedgerError;
+use crate::ledger_error::LedgerError;
 use colored::*;
 
 struct BalanceAccount {

--- a/src/balance.rs
+++ b/src/balance.rs
@@ -1,6 +1,7 @@
 extern crate serde_yaml;
 
 use super::models::LedgerFile;
+use crate::error::LedgerError;
 use colored::*;
 
 struct BalanceAccount {
@@ -14,7 +15,7 @@ struct TransactionAccount {
 }
 
 /// returns balances of all general ledger accounts
-pub fn balance(filename: &String) -> Result<(), std::io::Error> {
+pub fn balance(filename: &String) -> Result<(), LedgerError> {
     let file = std::fs::File::open(filename)?;
     let deserialized_file: LedgerFile = serde_yaml::from_reader(file).unwrap();
 

--- a/src/csv.rs
+++ b/src/csv.rs
@@ -1,6 +1,7 @@
 extern crate csv;
 
 use super::models::LedgerFile;
+use crate::error::LedgerError;
 use serde::{Deserialize, Serialize};
 use std::{fs, io::Write};
 
@@ -59,7 +60,7 @@ fn insert_match_acct(csv_matches: &[CSVMatches], record: &CSV) -> String {
 }
 
 /// convert csv to yaml format
-pub fn csv(ledger_file: &String, csv_file: &String) -> Result<(), std::io::Error> {
+pub fn csv(ledger_file: &String, csv_file: &String) -> Result<(), LedgerError> {
     // open csv file
     let raw_csv_file = fs::File::open(csv_file)?;
     let mut csv_reader = csv::Reader::from_reader(raw_csv_file);

--- a/src/csv.rs
+++ b/src/csv.rs
@@ -1,7 +1,7 @@
 extern crate csv;
 
 use super::models::LedgerFile;
-use crate::error::LedgerError;
+use crate::ledger_error::LedgerError;
 use serde::{Deserialize, Serialize};
 use std::{fs, io::Write};
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,50 @@
-use std::io::{Error, ErrorKind};
+use std::error;
+use std::fmt;
+use std::io::Error;
 
-/// returns an error if a command is not provided
-pub fn error() -> Result<(), std::io::Error> {
-    Err(Error::new(
-        ErrorKind::InvalidInput,
-        "invalid input: please provide a command",
-    ))
+extern crate csv;
+
+#[derive(Debug)]
+pub enum LedgerError {
+    InputError(Error),
+    CSVError(csv::Error),
+}
+
+impl fmt::Display for LedgerError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            LedgerError::InputError(ref err) => {
+                write!(f, "Input error. Argument is not correct: {}", err)
+            }
+            LedgerError::CSVError(ref err) => write!(f, "CSV error: {}", err),
+        }
+    }
+}
+
+impl error::Error for LedgerError {
+    fn description(&self) -> &str {
+        match *self {
+            LedgerError::InputError(ref err) => err.description(),
+            LedgerError::CSVError(ref err) => err.description(),
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            LedgerError::InputError(ref err) => Some(err),
+            LedgerError::CSVError(ref err) => Some(err),
+        }
+    }
+}
+
+impl From<Error> for LedgerError {
+    fn from(err: Error) -> LedgerError {
+        LedgerError::InputError(err)
+    }
+}
+
+impl From<csv::Error> for LedgerError {
+    fn from(err: csv::Error) -> LedgerError {
+        LedgerError::CSVError(err)
+    }
 }

--- a/src/ledger_error.rs
+++ b/src/ledger_error.rs
@@ -1,13 +1,13 @@
-use std::error;
 use std::fmt;
-use std::io::Error;
+use std::io;
 
 extern crate csv;
 
 #[derive(Debug)]
 pub enum LedgerError {
-    InputError(Error),
+    InputError(io::Error),
     CSVError(csv::Error),
+    Other(String),
 }
 
 impl fmt::Display for LedgerError {
@@ -17,28 +17,13 @@ impl fmt::Display for LedgerError {
                 write!(f, "Input error. Argument is not correct: {}", err)
             }
             LedgerError::CSVError(ref err) => write!(f, "CSV error: {}", err),
+            LedgerError::Other(ref s) => write!(f, "other error: {}", s),
         }
     }
 }
 
-impl error::Error for LedgerError {
-    fn description(&self) -> &str {
-        match *self {
-            LedgerError::InputError(ref err) => err.description(),
-            LedgerError::CSVError(ref err) => err.description(),
-        }
-    }
-
-    fn cause(&self) -> Option<&error::Error> {
-        match *self {
-            LedgerError::InputError(ref err) => Some(err),
-            LedgerError::CSVError(ref err) => Some(err),
-        }
-    }
-}
-
-impl From<Error> for LedgerError {
-    fn from(err: Error) -> LedgerError {
+impl From<io::Error> for LedgerError {
+    fn from(err: io::Error) -> LedgerError {
         LedgerError::InputError(err)
     }
 }
@@ -46,5 +31,11 @@ impl From<Error> for LedgerError {
 impl From<csv::Error> for LedgerError {
     fn from(err: csv::Error) -> LedgerError {
         LedgerError::CSVError(err)
+    }
+}
+
+impl From<String> for LedgerError {
+    fn from(err: String) -> LedgerError {
+        LedgerError::Other(err)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ mod register;
 use pargs;
 use std::env;
 
-fn main() -> Result<(), std::io::Error> {
+fn main() -> Result<(), error::LedgerError> {
     // collect args from user input
     let args: Vec<String> = env::args().collect();
 
@@ -51,7 +51,7 @@ fn main() -> Result<(), std::io::Error> {
             "balances" => balance::balance(&ledger_file.to_string()),
             "register" => register::register(&ledger_file.to_string(), &options_arg.to_string()),
             "csv" => csv::csv(&ledger_file.to_string(), &options_arg.to_string()),
-            _ => error::error(),
+            _ => break,
         };
     })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,11 +45,13 @@ fn main() -> Result<(), std::io::Error> {
         None => "",
     };
 
-    match &pargs_commands[0][..] {
-        "accounts" => accounts::accounts(&ledger_file.to_string()),
-        "balances" => balance::balance(&ledger_file.to_string()),
-        "register" => register::register(&ledger_file.to_string(), &options_arg.to_string()),
-        "csv" => csv::csv(&ledger_file.to_string(), &options_arg.to_string()),
-        _ => error::error(),
-    }
+    Ok(for cmd in pargs_commands {
+        return match &cmd[..] {
+            "accounts" => accounts::accounts(&ledger_file.to_string()),
+            "balances" => balance::balance(&ledger_file.to_string()),
+            "register" => register::register(&ledger_file.to_string(), &options_arg.to_string()),
+            "csv" => csv::csv(&ledger_file.to_string(), &options_arg.to_string()),
+            _ => error::error(),
+        };
+    })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,15 @@
 mod accounts;
 mod balance;
 mod csv;
-mod error;
+mod ledger_error;
 mod models;
 mod register;
 
 use pargs;
 use std::env;
+use std::io::{Error, ErrorKind};
 
-fn main() -> Result<(), error::LedgerError> {
+fn main() -> Result<(), ledger_error::LedgerError> {
     // collect args from user input
     let args: Vec<String> = env::args().collect();
 
@@ -45,13 +46,20 @@ fn main() -> Result<(), error::LedgerError> {
         None => "",
     };
 
-    Ok(for cmd in pargs_commands {
-        return match &cmd[..] {
+    match &pargs_commands.len() {
+        0 => Err(ledger_error::LedgerError::InputError(Error::new(
+            ErrorKind::InvalidInput,
+            "Invalid argument was entered. Please try again.",
+        ))),
+        _ => match &pargs_commands[0][..] {
             "accounts" => accounts::accounts(&ledger_file.to_string()),
             "balances" => balance::balance(&ledger_file.to_string()),
             "register" => register::register(&ledger_file.to_string(), &options_arg.to_string()),
             "csv" => csv::csv(&ledger_file.to_string(), &options_arg.to_string()),
-            _ => break,
-        };
-    })
+            _ => Err(ledger_error::LedgerError::InputError(Error::new(
+                ErrorKind::InvalidInput,
+                "Invalid argument was entered. Please try again.",
+            ))),
+        },
+    }
 }

--- a/src/register.rs
+++ b/src/register.rs
@@ -1,10 +1,11 @@
 extern crate serde_yaml;
 
 use super::models::{LedgerFile, Transaction};
+use crate::error::LedgerError;
 use colored::*;
 
 /// returns all general ledger transactions
-pub fn register(filename: &String, option: &String) -> Result<(), std::io::Error> {
+pub fn register(filename: &String, option: &String) -> Result<(), LedgerError> {
     let file = std::fs::File::open(filename)?;
     let deserialized_file: LedgerFile = serde_yaml::from_reader(file).unwrap();
 

--- a/src/register.rs
+++ b/src/register.rs
@@ -1,7 +1,7 @@
 extern crate serde_yaml;
 
 use super::models::{LedgerFile, Transaction};
-use crate::error::LedgerError;
+use crate::ledger_error::LedgerError;
 use colored::*;
 
 /// returns all general ledger transactions


### PR DESCRIPTION
Fixes: 
- Improves error handling by defining custom errors for more informative messaging for users.
- 3 custom errors have been defined: `InputError`, `CSVError` and `Other`. These errors would catch incorrect arguments, errors in CSV parsing and other situations, respectively. None of the code is consuming the `Other` error type currently, but it is there for future utilization if we need it. 
- The `InputError` now prints this to `stdout`:
`Error: InputError(Custom { kind: InvalidInput, error: "Invalid argument was entered. Please try again." })`

Tests:
- Build passes
- Clone this branch locally. Invoke the CLI with an incorrect argument (such as `reg` instead of `register`) and note that the error message is bit more helpful. 