### PR TITLE
Feature - group register output by year or month

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,20 +5,25 @@ name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "hermit-abi 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hermit-abi 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bstr"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-automata 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -27,13 +32,24 @@ version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "chrono"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "colored"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -41,11 +57,11 @@ name = "csv"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bstr 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bstr 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ryu 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -58,20 +74,20 @@ dependencies = [
 
 [[package]]
 name = "dtoa"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "itoa"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -81,12 +97,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.68"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -103,6 +119,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "pargs"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,12 +145,12 @@ name = "proc-macro2"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.3"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -135,35 +168,36 @@ dependencies = [
 name = "rust_ledger"
 version = "0.3.0"
 dependencies = [
+ "chrono 0.4.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "monee 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "pargs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_derive 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -171,30 +205,39 @@ name = "serde_yaml"
 version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "dtoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dtoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linked-hash-map 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yaml-rust 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.36"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -213,38 +256,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "yaml-rust"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linked-hash-map 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-"checksum bstr 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "2889e6d50f394968c8bf4240dc3f2a7eb4680844d27308f798229ac9d4725f41"
+"checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+"checksum bstr 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931"
 "checksum byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+"checksum chrono 0.4.15 (registry+https://github.com/rust-lang/crates.io-index)" = "942f72db697d8767c22d46a598e01f2d3b475501ea43d0db4f16d90259182d0b"
 "checksum colored 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
 "checksum csv 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "00affe7f6ab566df61b4be3ce8cf16bc2576bca0963ceb0955e45d514bf9a279"
 "checksum csv-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
-"checksum dtoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
-"checksum hermit-abi 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71"
-"checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
+"checksum dtoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
+"checksum hermit-abi 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
+"checksum itoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-"checksum libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)" = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
-"checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
+"checksum libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f02823cf78b754822df5f7f268fb59822e7296276d3e069d8e8cb26a14bd10"
+"checksum linked-hash-map 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
 "checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 "checksum monee 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "10185d7e26610b2ca56d56254e26b1654bbe964e7bd94be07d726f964d19d2db"
+"checksum num-integer 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
+"checksum num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 "checksum pargs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9af613895e670c4fe40d887de135a1becff72a2fc67352669bfe80ee4d650520"
 "checksum proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
-"checksum quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
+"checksum quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 "checksum regex-automata 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
-"checksum ryu 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
-"checksum serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
-"checksum serde_derive 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
+"checksum ryu 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+"checksum serde 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)" = "e54c9a88f2da7238af84b5101443f0c0d0a3bbdc455e34a5c9497b1903ed55d5"
+"checksum serde_derive 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)" = "609feed1d0a73cc36a0182a840a9b37b4a82f0b1150369f0536a9e3f2a31dc48"
 "checksum serde_yaml 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)" = "ae3e2dd40a7cdc18ca80db804b7f461a39bb721160a85c9a1fa30134bf3c02a5"
-"checksum syn 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)" = "4cdb98bcb1f9d81d07b536179c269ea15999b5d14ea958196413869445bb5250"
-"checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
-"checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
+"checksum syn 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)" = "e69abc24912995b3038597a7a593be5053eb0fb44f3cc5beec0deb421790c1f4"
+"checksum time 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+"checksum unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+"checksum winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-"checksum yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d"
+"checksum yaml-rust 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "39f0c922f1a334134dc2f7a8b67dc5d25f0735263feec974345ff706bcf20b0d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ csv = "1.1.3"
 pargs = "0.1.4" 
 colored = "2.0.0"
 monee = "0.0.5"
+chrono = { version = "0.4", features = ["serde"] }

--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ Alternatively, clone this repo and do the following:
 
 ### Usage
 
-`rust_ledger -l LEDGER_FILE_PATH COMMAND -f OPTION`
+`rust_ledger -f LEDGER_FILE_PATH COMMAND -o OPTION`
 
-LEDGER_FILE_PATH (denoted by `-l`) - relative path to location of yaml ledger file
+LEDGER_FILE_PATH (denoted by `-f`) - relative path to location of yaml ledger file
 
   - Optionally, the ledger file path can be set via the environment variable `RLEDGER_FILE` in lieu of specifying whenever the program is invoked.
-  - If `-l` is provided with a file path the file provided will be used instead of any `RLEDGER_FILE` set.
+  - If `-f` is provided with a file path the file provided will be used instead of any `RLEDGER_FILE` set.
 
 ```
 RLEDGER_FILE=~/rledger.yaml rust_ledger balances
@@ -56,7 +56,9 @@ export RLEDGER_FILE="$HOME/rledger.yaml"
 
 COMMAND - ledger command (account, balance, register, or csv)
 
-OPTION (denoted by `-f`) - allows you to filter the output of the `register` command by account type. For example, if you wish to only see "expense" transactions in the output, you would pass in `expense` as the option here.
+OPTION (denoted by `-o`) - allows you to filter the output of the `register` command by account type. For example, if you wish to only see "expense" transactions in the output, you would pass in `expense` as the option here.
+
+GROUP (denoted by `-g`) - allows you to group the output of the `register` command by `year` or `month`. 
 
 ### Environment Variables
 
@@ -87,7 +89,7 @@ Transactions that involve more than two accounts are expressed in the following 
 ```yaml
 - date: 01/01/2020
   description: grocery store
-  transaction:
+  transactions:
     - amount: 20
       account: expense:general
     - amount: 180

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ GROUP (denoted by `-g`) - allows you to group the output of the `register` comma
 Transactions can be expressed in two different ways. One is a "simplified" format for transactions that only impact two accounts: 
 
 ```yaml
-- date: 01/01/2020
+- date: 2020-01-01
   amount: 200
   offset_account: liability:credit_card_amex
   description: grocery store
@@ -156,13 +156,13 @@ check                          0
 ```
 Date       Description             Accounts              
 ---------------------------------------------------------------------------------
-11/4/2019  weekly groceries        grocery                  $ 455.00     $ 455.00
+2019-12-31 weekly groceries        grocery                  $ 455.00     $ 455.00
                                    credit_card_amex        $ -455.00            0
-07/04/2020 mortage                 mortgage                $ 2000.00    $ 2000.00
+2020-01-01 mortage                 mortgage                $ 2000.00    $ 2000.00
                                    cash_checking          $ -2000.00            0
-07/04/2020 stuff                   general                 $ 1000.00    $ 1000.00
+2020-01-01 stuff                   general                 $ 1000.00    $ 1000.00
                                    cash_savings           $ -1000.00            0
-06/21/2020 grocery store           general                   $ 20.00      $ 20.00
+2020-01-01 grocery store           general                   $ 20.00      $ 20.00
                                    grocery                  $ 180.00     $ 200.00
                                    cash_checking           $ -200.00            0
 ```
@@ -201,5 +201,5 @@ transactions:
 The ledger format schema is purposely lightweight. The only requirements are as follows:
 - the `account` field should be expressed in the following format: `account_classification:account_name`.
 - the `amount` field should be a number. It can include up to two (2) decimal points.  
-- the `date` field should be in the following format: `MM-DD-YYYY`. 
+- the `date` field should be in the following format: `YYYY-MM-DD`. 
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ transactions:
     offset_account: 
   - date: 
     description: 
-    transaction: 
+    transactions: 
       - amount: 
         account: 
       - amount: 
@@ -197,6 +197,7 @@ transactions:
 ```
 
 The ledger format schema is purposely lightweight. The only requirements are as follows:
-    - the `account` field should be expressed in the following format: `account_classification:account_name`.
-    - the `amount` field should be a number. It can include up to two (2) decimal points.  
-    - the `date` field should be in the following format: `MM-DD-YYYY`. 
+- the `account` field should be expressed in the following format: `account_classification:account_name`.
+- the `amount` field should be a number. It can include up to two (2) decimal points.  
+- the `date` field should be in the following format: `MM-DD-YYYY`. 
+

--- a/examples/example.yaml
+++ b/examples/example.yaml
@@ -29,14 +29,14 @@ transactions:
     offset_account: asset:cash_checking
   - date: 07/04/2020
     description: stuff
-    transaction: 
+    transactions: 
       - amount: 1000
         account: expense:general
       - amount: -1000
         account: asset:cash_savings
   - date: 06/21/2020
     description: grocery store
-    transaction:
+    transactions:
       - amount: 20
         account: expense:general
       - amount: 180

--- a/examples/example.yaml
+++ b/examples/example.yaml
@@ -17,24 +17,24 @@ accounts:
     amount: 0
 
 transactions:
-  - date: 11/4/2019
+  - date: 2019-12-31 
     amount: 455
     description: weekly groceries
     account: expense:grocery
     offset_account: liability:credit_card_amex
-  - date: 07/04/2020
+  - date: 2020-01-01 
     amount: 2000
     description: mortage
     account: expense:mortgage
     offset_account: asset:cash_checking
-  - date: 07/04/2020
+  - date: 2020-01-01 
     description: stuff
     transactions: 
       - amount: 1000
         account: expense:general
       - amount: -1000
         account: asset:cash_savings
-  - date: 06/21/2020
+  - date: 2020-01-01 
     description: grocery store
     transactions:
       - amount: 20

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,6 +4,7 @@ mod csv;
 mod register;
 
 use crate::error::{Error, Result};
+use crate::model::ledger::Group;
 use pargs;
 use std::env;
 
@@ -18,7 +19,7 @@ pub fn run() -> Result<()> {
         String::from("csv"),
     ];
     let flag_args: Vec<String> = vec![];
-    let option_args: Vec<String> = vec![String::from("-l"), String::from("-f")];
+    let option_args: Vec<String> = vec![String::from("-f"), String::from("-o"), String::from("-g")];
 
     // pargs will parse the args and return the result
     let pargs_result = pargs::parse(args, command_args, flag_args, option_args)?;
@@ -26,7 +27,7 @@ pub fn run() -> Result<()> {
     let pargs_options = pargs_result.option_args;
     let pargs_commands = pargs_result.command_args;
 
-    let ledger_file = match pargs_options.get("-l") {
+    let ledger_file = match pargs_options.get("-f") {
         Some(value) => value.to_string(),
         None => {
             let ledger_file_env = match std::env::var("RLEDGER_FILE") {
@@ -38,9 +39,18 @@ pub fn run() -> Result<()> {
         }
     };
 
-    let options_arg = match pargs_options.get("-f") {
+    let options_arg = match pargs_options.get("-o") {
         Some(value) => value,
         None => "",
+    };
+
+    let group_arg = match pargs_options.get("-g") {
+        Some(value) => match value.as_str() {
+            "month" => Group::Month,
+            "year" => Group::Year,
+            _ => panic!("that group command was not recognized."),
+        },
+        None => Group::None,
     };
 
     match &pargs_commands.len() {
@@ -48,7 +58,11 @@ pub fn run() -> Result<()> {
         _ => match &pargs_commands[0][..] {
             "account" => account::account(&ledger_file.to_string()),
             "balance" => balance::balance(&ledger_file.to_string()),
-            "register" => register::register(&ledger_file.to_string(), &options_arg.to_string()),
+            "register" => register::register(
+                &ledger_file.to_string(),
+                &options_arg.to_string(),
+                group_arg,
+            ),
             "csv" => csv::csv(&ledger_file.to_string(), &options_arg.to_string()),
             _ => panic!("command not found.".to_string()),
         },

--- a/src/cli/register.rs
+++ b/src/cli/register.rs
@@ -1,14 +1,18 @@
 extern crate serde_yaml;
 
 use crate::error::Result;
-use crate::model::ledger::LedgerFile;
+use crate::model::ledger::{Group, LedgerFile};
 
 /// returns all general ledger transactions
-pub fn register(filename: &String, option: &String) -> Result<()> {
+pub fn register(filename: &String, option: &String, group: Group) -> Result<()> {
     let file = std::fs::File::open(filename)?;
     let deserialized_file: LedgerFile = serde_yaml::from_reader(file).unwrap();
 
-    LedgerFile::print_register(deserialized_file, option);
+    if group == Group::None {
+        LedgerFile::print_register(deserialized_file, option)
+    } else {
+        LedgerFile::print_register_group(deserialized_file, option, group)
+    }
 
     Ok(())
 }

--- a/src/model/ledger.rs
+++ b/src/model/ledger.rs
@@ -317,9 +317,9 @@ impl LedgerFile {
                 ..
             } = OptionalKeys::match_optional_keys(&transaction);
 
-            let date: Vec<&str> = transaction.date.split("/").collect();
-            let month = date[0].to_string();
-            let year = date[2].to_string();
+            let date: Vec<&str> = transaction.date.split("-").collect();
+            let year = date[0].to_string();
+            let month = year.clone() + "-" + date[1];
 
             match group {
                 Group::Month => group_map.populate_group_map(month, amount, transactions),

--- a/src/model/ledger.rs
+++ b/src/model/ledger.rs
@@ -350,71 +350,30 @@ impl LedgerFile {
 
         for t in filtered_transactions {
             let OptionalKeys {
-                account,
-                offset_account,
-                amount,
-                ..
+                account, amount, ..
             } = OptionalKeys::match_optional_fields(&t);
 
             let account_vec: Vec<&str> = account.split(":").collect();
             let account_type = account_vec[0];
             let account_name = account_vec[1];
 
-            let offset_account_vec: Vec<&str> = offset_account.split(":").collect();
-            let offset_account_name = offset_account_vec[1];
-
             match account_type {
                 "income" => {
-                    match &offset_account[..] {
-                        "optional:account" => continue,
-                        _ => {
-                            println!(
-                                "{0: <10} {1: <23} {2: <20} {3: >12}",
-                                t.date,
-                                t.description.bold(),
-                                offset_account_name,
-                                format!("{: >1}", money!(amount, "USD")).to_string().bold(),
-                            );
-                        }
-                    }
-                    match &account[..] {
-                        "optional:account" => continue,
-                        _ => {
-                            println!(
-                                "{0: <35}{1: <20} {2: >12} {3: >12}",
-                                "",
-                                account_name,
-                                format!("{: >1}", money!(-amount, "USD")).to_string().bold(),
-                                "0".bold()
-                            );
-                        }
-                    }
+                    println!(
+                        "{0: <35}{1: <20} {2: >12} {3: >20}",
+                        "",
+                        account_name,
+                        format!("{: >1}", money!(-amount, "USD")).to_string().bold(),
+                        "0".bold()
+                    );
                 }
-                _ => {
-                    match &account[..] {
-                        "optional:account" => continue,
-                        _ => {
-                            println!(
-                                "{0: <10} {1: <23} {2: <20} {3: >12}",
-                                t.date,
-                                t.description.bold(),
-                                account_name,
-                                format!("{: >1}", money!(amount, "USD")).to_string().bold(),
-                            );
-                        }
-                    }
-                    match &offset_account[..] {
-                        "optional:account" => continue,
-                        _ => {
-                            println!(
-                                "{0: <35}{1: <20} {2: >12}",
-                                "",
-                                offset_account_name,
-                                format!("{: >1}", money!(-amount, "USD")).to_string().bold(),
-                            );
-                        }
-                    }
-                }
+                _ => println!(
+                    "{0: <10} {1: <23} {2: <20} {3: >20}",
+                    t.date,
+                    t.description.bold(),
+                    account_name,
+                    format!("{: >1}", money!(amount, "USD")).to_string().bold(),
+                ),
             };
         }
 

--- a/src/model/ledger.rs
+++ b/src/model/ledger.rs
@@ -1,6 +1,15 @@
 use colored::*;
 use monee::*;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// root data structure that contains the deserialized ledger file data
+/// and associated structs
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct LedgerFile {
+    pub accounts: Vec<Account>,
+    pub transactions: Vec<Transaction>,
+}
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Account {
@@ -8,26 +17,175 @@ pub struct Account {
     pub amount: f64,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-pub struct TransactionList {
-    pub account: String,
-    pub amount: f64,
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Transaction {
     pub date: String,
     pub account: Option<String>,
     pub amount: Option<f64>,
     pub description: String,
     pub offset_account: Option<String>,
-    pub transaction: Option<Vec<TransactionList>>,
+    pub transactions: Option<Vec<TransactionList>>,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-pub struct LedgerFile {
-    pub accounts: Vec<Account>,
-    pub transactions: Vec<Transaction>,
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct TransactionList {
+    pub account: String,
+    pub amount: f64,
+}
+
+/// enumerates all possible "group" values for pattern matching
+#[derive(Debug, PartialEq)]
+pub enum Group {
+    Month,
+    Year,
+    None,
+}
+
+/// data structure for handling optional values contained
+/// within the LedgerFile for ease of program access
+#[derive(Debug, PartialEq)]
+struct OptionalKeys {
+    account: String,
+    offset_account: String,
+    amount: f64,
+    transactions: Vec<TransactionList>,
+}
+
+impl OptionalKeys {
+    fn match_optional_fields(transaction: &Transaction) -> Self {
+        let account = match &transaction.account {
+            None => "optional:account".to_string(),
+            Some(name) => name.to_string(),
+        };
+
+        let offset_account = match &transaction.offset_account {
+            None => "optional:account".to_string(),
+            Some(name) => name.to_string(),
+        };
+
+        let amount = match transaction.amount {
+            None => 0.00,
+            Some(number) => number,
+        };
+
+        let transactions = match transaction.transactions.clone() {
+            None => vec![],
+            Some(list) => list,
+        };
+
+        return Self {
+            account,
+            offset_account,
+            amount,
+            transactions,
+        };
+    }
+}
+/// data structure for maintaining summarized register data
+/// keyed by range
+#[derive(Debug, PartialEq)]
+struct GroupMap {
+    group_map: HashMap<String, f64>,
+}
+
+impl GroupMap {
+    fn new() -> GroupMap {
+        GroupMap {
+            group_map: HashMap::new(),
+        }
+    }
+
+    fn populate_group_map(
+        &mut self,
+        range: String,
+        amount: f64,
+        transactions: Vec<TransactionList>,
+    ) {
+        let prev_value = match self.group_map.get(&range) {
+            Some(value) => value,
+            None => &0.00,
+        };
+
+        if amount != 0.00 {
+            let inc_value = prev_value + amount;
+            self.group_map.insert(range, inc_value);
+        } else if !transactions.is_empty() {
+            for t in transactions {
+                self.group_map.insert(range.clone(), t.amount);
+            }
+        }
+    }
+}
+
+/// flatten abbreviated and detailed LedgerFile transactions into
+/// a Vec containing individual detailed transactions.
+/// all downstream logic expects this data structure.
+fn flatten_transactions(transactions: LedgerFile) -> Vec<Transaction> {
+    let mut flattened_transactions: Vec<Transaction> = Vec::new();
+
+    for t in transactions.transactions {
+        let OptionalKeys { amount, .. } = OptionalKeys::match_optional_fields(&t);
+        match t.transactions {
+            Some(subt) => {
+                for s in subt {
+                    flattened_transactions.push(Transaction {
+                        date: t.date.clone(),
+                        account: Some(s.account),
+                        amount: Some(s.amount),
+                        transactions: None,
+                        description: t.description.clone(),
+                        offset_account: None,
+                    });
+                }
+            }
+            None => {
+                // push entry
+                flattened_transactions.push(Transaction {
+                    account: t.account.clone(),
+                    offset_account: None,
+                    amount: t.amount.clone(),
+                    ..t.clone()
+                });
+
+                // push offset entry
+                flattened_transactions.push(Transaction {
+                    account: t.offset_account,
+                    offset_account: None,
+                    amount: Some(amount * -1.00),
+                    ..t
+                });
+            }
+        }
+    }
+
+    return flattened_transactions;
+}
+
+/// filter transactions by option. Downstream logic pairs this with
+/// the "group" argument for more extensive filtering
+fn filter_transactions_by_option(transactions: LedgerFile, option: &String) -> Vec<Transaction> {
+    let flattened_transactions = flatten_transactions(transactions);
+
+    return flattened_transactions
+        .into_iter()
+        .filter(|x| match option.as_str() {
+            "" => true,
+            _ => {
+                let OptionalKeys {
+                    account,
+                    offset_account,
+                    amount,
+                    ..
+                } = OptionalKeys::match_optional_fields(&x);
+
+                x.date.contains(option)
+                    || amount.to_string().contains(option)
+                    || account.contains(option)
+                    || offset_account.contains(option)
+                    || x.description.contains(option)
+            }
+        })
+        .collect();
 }
 
 impl LedgerFile {
@@ -56,68 +214,34 @@ impl LedgerFile {
 
         // push transactions into Vec
         for transaction in self.transactions {
-            let optional_account = match transaction.account {
-                None => "".to_string(),
-                Some(name) => name,
+            let OptionalKeys {
+                account,
+                offset_account,
+                amount,
+                ..
+            } = OptionalKeys::match_optional_fields(&transaction);
+            let account_type: Vec<&str> = account.split(":").collect();
+
+            let debit_credit = match account_type[0] {
+                "income" => -amount,
+                _ => amount,
             };
 
-            let optional_amount = match transaction.amount {
-                None => 0.00,
-                Some(number) => number,
-            };
+            transactions_vec.push(Account {
+                account: account.clone(),
+                amount: debit_credit,
+            });
 
-            let account_type: Vec<&str> = optional_account.split(":").collect();
-
-            match transaction.transaction {
-                None => {
-                    let offset_account = match transaction.offset_account {
-                        None => "".to_string(),
-                        Some(name) => name,
-                    };
-
-                    let amount = match account_type[0] {
-                        "income" => -optional_amount,
-                        _ => optional_amount,
-                    };
-
-                    transactions_vec.push(Account {
-                        account: optional_account,
-                        amount,
-                    });
-
-                    if !offset_account.is_empty() {
-                        transactions_vec.push(Account {
-                            account: offset_account,
-                            amount: -amount,
-                        });
-                    }
-                }
-                Some(split) => {
-                    let mut credit: f64 = 0.0;
-
-                    for i in split {
-                        let amount = match account_type[0] {
-                            "income" => -i.amount,
-                            _ => i.amount,
-                        };
-                        credit += amount;
-                        transactions_vec.push(Account {
-                            account: i.account,
-                            amount: i.amount,
-                        })
-                    }
-
-                    transactions_vec.push(Account {
-                        account: optional_account,
-                        amount: optional_amount - credit,
-                    });
-                }
+            if !offset_account.is_empty() {
+                transactions_vec.push(Account {
+                    account: offset_account.clone(),
+                    amount: -amount.clone(),
+                });
             }
         }
 
         // loop over Vecs and increment(+)/decrement(-) totals
         // for each transaction
-
         for transaction in &transactions_vec {
             let transaction_account_type: Vec<&str> = transaction.account.split(":").collect();
 
@@ -133,14 +257,11 @@ impl LedgerFile {
         }
 
         // create output
-
         let mut check_figure: f64 = 0.0;
+        let mut current_account_type = String::new();
 
         println!("{0: <29} {1: <20}", "Account".bold(), "Balance".bold());
-
         println!("{0:-<39}", "".bright_blue());
-
-        let mut current_account_type = String::new();
 
         for account in accounts_vec {
             check_figure += account.amount;
@@ -171,6 +292,7 @@ impl LedgerFile {
 
         println!("\n{:-<39}", "".bright_blue());
         print!("{: <30}", "check");
+
         if check_figure == 0.0 {
             print!(" {:<20}\n", check_figure.to_string().bold());
         } else {
@@ -178,6 +300,40 @@ impl LedgerFile {
         }
 
         println!("\n");
+    }
+
+    pub fn print_register_group(self, option: &String, group: Group) {
+        let mut group_map = GroupMap::new();
+        let filtered_transactions = filter_transactions_by_option(self, option);
+
+        println!("\n{0: <10} {1: <23} ", "Date".bold(), "Total".bold());
+        println!("{0:-<81}", "".bright_blue());
+
+        for transaction in filtered_transactions {
+            let OptionalKeys {
+                amount,
+                transactions,
+                ..
+            } = OptionalKeys::match_optional_fields(&transaction);
+
+            let date: Vec<&str> = transaction.date.split("/").collect();
+            let month = date[0].to_string();
+            let year = date[2].to_string();
+
+            match group {
+                Group::Month => group_map.populate_group_map(month, amount, transactions),
+                Group::Year => group_map.populate_group_map(year, amount, transactions),
+                Group::None => (),
+            }
+        }
+
+        for (k, v) in group_map.group_map.iter() {
+            println!(
+                "{0: <10} {1: <23}",
+                k,
+                format!("{: >1}", money!(v, "USD")).to_string().bold()
+            );
+        }
     }
 
     pub fn print_register(self, option: &String) {
@@ -190,284 +346,76 @@ impl LedgerFile {
 
         println!("{0:-<81}", "".bright_blue());
 
-        let filtered_items: Vec<Transaction> = self
-            .transactions
-            .into_iter()
-            .filter(|x| match option.as_str() {
-                "all" => true,
-                _ => {
-                    let optional_account = match &x.account {
-                        None => "optional:account".to_string(),
-                        Some(name) => name.to_string(),
-                    };
+        let filtered_transactions = filter_transactions_by_option(self, option);
 
-                    let optional_offset_account = match &x.offset_account {
-                        None => "optional:account".to_string(),
-                        Some(name) => name.to_string(),
-                    };
+        for t in filtered_transactions {
+            let OptionalKeys {
+                account,
+                offset_account,
+                amount,
+                ..
+            } = OptionalKeys::match_optional_fields(&t);
 
-                    let optional_amount = match x.amount {
-                        None => 0.00,
-                        Some(number) => number,
-                    };
-
-                    x.date.contains(option)
-                        || optional_amount.to_string().contains(option)
-                        || optional_account.contains(option)
-                        || optional_offset_account.contains(option)
-                        || x.description.contains(option)
-                }
-            })
-            .collect();
-
-        for item in filtered_items {
-            let optional_account = match item.account {
-                None => "optional:account".to_string(),
-                Some(name) => name,
-            };
-
-            let optional_offset_account = match item.offset_account {
-                None => "optional:account".to_string(),
-                Some(name) => name,
-            };
-
-            let optional_amount = match item.amount {
-                None => 0.00,
-                Some(number) => number,
-            };
-
-            let mut credit: f64 = 0.0;
-
-            let account_vec: Vec<&str> = optional_account.split(":").collect();
+            let account_vec: Vec<&str> = account.split(":").collect();
             let account_type = account_vec[0];
             let account_name = account_vec[1];
 
-            let offset_account_vec: Vec<&str> = optional_offset_account.split(":").collect();
+            let offset_account_vec: Vec<&str> = offset_account.split(":").collect();
             let offset_account_name = offset_account_vec[1];
 
-            match item.transaction {
-                None => {
-                    match account_type {
-                        "income" => {
-                            match &optional_offset_account[..] {
-                                "optional:account" => continue,
-                                _ => {
-                                    println!(
-                                        "{0: <10} {1: <23} {2: <20} {3: >12} {4: >12}",
-                                        item.date,
-                                        item.description.bold(),
-                                        offset_account_name,
-                                        format!("{: >1}", money!(optional_amount, "USD"))
-                                            .to_string()
-                                            .bold(),
-                                        format!("{: >1}", money!(optional_amount, "USD"))
-                                            .to_string()
-                                            .bold()
-                                    );
-                                }
-                            }
-                            match &optional_account[..] {
-                                "optional:account" => continue,
-                                _ => {
-                                    println!(
-                                        "{0: <35}{1: <20} {2: >12} {3: >12}",
-                                        "",
-                                        account_name,
-                                        format!("{: >1}", money!(-optional_amount, "USD"))
-                                            .to_string()
-                                            .bold(),
-                                        "0".bold() // hack for now. No need to do any math
-                                    );
-                                }
-                            }
-                        }
+            match account_type {
+                "income" => {
+                    match &offset_account[..] {
+                        "optional:account" => continue,
                         _ => {
-                            match &optional_account[..] {
-                                "optional:account" => continue,
-                                _ => {
-                                    println!(
-                                        "{0: <10} {1: <23} {2: <20} {3: >12} {4: >12}",
-                                        item.date,
-                                        item.description.bold(),
-                                        account_name,
-                                        format!("{: >1}", money!(optional_amount, "USD"))
-                                            .to_string()
-                                            .bold(),
-                                        format!("{: >1}", money!(optional_amount, "USD"))
-                                            .to_string()
-                                            .bold()
-                                    );
-                                }
-                            }
-                            match &optional_offset_account[..] {
-                                "optional:account" => continue,
-                                _ => {
-                                    println!(
-                                        "{0: <35}{1: <20} {2: >12} {3: >12}",
-                                        "",
-                                        offset_account_name,
-                                        format!("{: >1}", money!(-optional_amount, "USD"))
-                                            .to_string()
-                                            .bold(),
-                                        format!(
-                                            "{: >1}",
-                                            money!((optional_amount - optional_amount), "USD")
-                                        )
-                                        .to_string()
-                                        .bold()
-                                    );
-                                }
-                            }
+                            println!(
+                                "{0: <10} {1: <23} {2: <20} {3: >12}",
+                                t.date,
+                                t.description.bold(),
+                                offset_account_name,
+                                format!("{: >1}", money!(amount, "USD")).to_string().bold(),
+                            );
                         }
-                    };
-                }
-                Some(split) => {
-                    match account_type {
-                        "income" => {
-                            if let Some((last, elements)) = split.split_last() {
-                                match &optional_offset_account[..] {
-                                    "optional:account" => continue,
-                                    _ => {
-                                        println!(
-                                            "{0: <10} {1: <23} {2: <20} {3: >12} {4: >12}",
-                                            item.date,
-                                            item.description.bold(),
-                                            offset_account_name,
-                                            format!("{: >1}", money!(optional_amount, "USD"))
-                                                .to_string()
-                                                .bold(),
-                                            format!("{: >1}", money!(optional_amount, "USD"))
-                                                .to_string()
-                                                .bold()
-                                        );
-                                    }
-                                }
-                                for i in elements {
-                                    credit -= i.amount;
-                                    let i_account_vec: Vec<&str> = i.account.split(":").collect();
-                                    let i_account_name = i_account_vec[1];
-
-                                    match &i.account[..] {
-                                        "optional:account" => continue,
-                                        _ => {
-                                            println!(
-                                                "{0: <35}{1: <20} {2: >12} {3: >12}",
-                                                "",
-                                                i_account_name,
-                                                format!("{: >1}", money!(i.amount, "USD"))
-                                                    .to_string()
-                                                    .bold(),
-                                                format!("{: >1}", money!(credit, "USD"))
-                                                    .to_string()
-                                                    .bold()
-                                            );
-                                        }
-                                    }
-                                }
-
-                                credit -= last.amount;
-                                let check: f64 = optional_amount - credit;
-
-                                let last_account_vec: Vec<&str> = last.account.split(":").collect();
-                                let last_account_name = last_account_vec[1];
-
-                                match &last.account[..] {
-                                    "optional:account" => continue,
-                                    _ => {
-                                        println!(
-                                            "{0: <35}{1: <20} {2: >12} {3: >12}",
-                                            "",
-                                            last_account_name,
-                                            format!("{: >1}", money!(last.amount, "USD"))
-                                                .to_string()
-                                                .bold(),
-                                            if check != 0.0 {
-                                                format!("{: >1}", money!(check, "USD"))
-                                                    .to_string()
-                                                    .red()
-                                                    .bold()
-                                            } else {
-                                                check.to_string().bold()
-                                            }
-                                        );
-                                    }
-                                }
-                            }
-                        }
+                    }
+                    match &account[..] {
+                        "optional:account" => continue,
                         _ => {
-                            if let Some((first, elements)) = split.split_first() {
-                                credit += first.amount;
-
-                                let first_account_vec: Vec<&str> =
-                                    first.account.split(":").collect();
-                                let first_account_name = first_account_vec[1];
-
-                                match &first.account[..] {
-                                    "optional:account" => continue,
-                                    _ => {
-                                        println!(
-                                            "{0: <10} {1: <23} {2: <20} {3: >12} {4: >12}",
-                                            item.date,
-                                            item.description.bold(),
-                                            first_account_name,
-                                            format!("{: >1}", money!(first.amount, "USD"))
-                                                .to_string()
-                                                .bold(),
-                                            format!("{: >1}", money!(first.amount, "USD"))
-                                                .to_string()
-                                                .bold()
-                                        );
-                                    }
-                                }
-
-                                for i in elements {
-                                    credit += i.amount;
-                                    let i_account_vec: Vec<&str> = i.account.split(":").collect();
-                                    let i_account_name = i_account_vec[1];
-
-                                    match &i.account[..] {
-                                        "optional:account" => continue,
-                                        _ => {
-                                            println!(
-                                                "{0: <35}{1: <20} {2: >12} {3: >12}",
-                                                "",
-                                                i_account_name,
-                                                format!("{: >1}", money!(i.amount, "USD"))
-                                                    .to_string()
-                                                    .bold(),
-                                                format!("{: >1}", money!(credit, "USD"))
-                                                    .to_string()
-                                                    .bold()
-                                            );
-                                        }
-                                    }
-                                }
-
-                                let check: f64 = optional_amount - credit;
-
-                                match &optional_offset_account[..] {
-                                    "optional:account" => continue,
-                                    _ => {
-                                        println!(
-                                            "{0: <35}{1: <20} {2: >12} {3: >12}",
-                                            "",
-                                            offset_account_name,
-                                            format!("{: >1}", money!(-optional_amount, "USD"))
-                                                .to_string()
-                                                .bold(),
-                                            if check != 0.0 {
-                                                (check).to_string().red().bold()
-                                            } else {
-                                                (check).to_string().bold()
-                                            }
-                                        );
-                                    }
-                                }
-                            }
+                            println!(
+                                "{0: <35}{1: <20} {2: >12} {3: >12}",
+                                "",
+                                account_name,
+                                format!("{: >1}", money!(-amount, "USD")).to_string().bold(),
+                                "0".bold()
+                            );
                         }
-                    };
+                    }
                 }
-            }
+                _ => {
+                    match &account[..] {
+                        "optional:account" => continue,
+                        _ => {
+                            println!(
+                                "{0: <10} {1: <23} {2: <20} {3: >12}",
+                                t.date,
+                                t.description.bold(),
+                                account_name,
+                                format!("{: >1}", money!(amount, "USD")).to_string().bold(),
+                            );
+                        }
+                    }
+                    match &offset_account[..] {
+                        "optional:account" => continue,
+                        _ => {
+                            println!(
+                                "{0: <35}{1: <20} {2: >12}",
+                                "",
+                                offset_account_name,
+                                format!("{: >1}", money!(-amount, "USD")).to_string().bold(),
+                            );
+                        }
+                    }
+                }
+            };
         }
 
         println!("\n");
@@ -494,7 +442,7 @@ fn print_accounts_to_stdout() {
             amount: Some(10.00),
             description: "test".to_string(),
             offset_account: Some("expenses:foo".to_string()),
-            transaction: None,
+            transactions: None,
         }],
     };
 
@@ -521,7 +469,7 @@ fn print_balances_to_stdout() {
             amount: Some(10.00),
             description: "test".to_string(),
             offset_account: Some("expenses:foo".to_string()),
-            transaction: None,
+            transactions: None,
         }],
     };
 
@@ -548,7 +496,7 @@ fn print_register_to_stdout() {
             amount: Some(10.00),
             description: "test".to_string(),
             offset_account: Some("expenses:foo".to_string()),
-            transaction: None,
+            transactions: None,
         }],
     };
 

--- a/src/model/ledger.rs
+++ b/src/model/ledger.rs
@@ -81,6 +81,7 @@ impl OptionalKeys {
         };
     }
 }
+
 /// data structure for maintaining summarized register data
 /// keyed by range
 #[derive(Debug, PartialEq)]
@@ -461,4 +462,54 @@ fn print_register_to_stdout() {
 
     let result = LedgerFile::print_register(file, &"".to_string());
     assert_eq!(result, ())
+}
+
+#[test]
+fn rl_flatten_transactions() {
+    let file: LedgerFile = LedgerFile {
+        accounts: vec![
+            Account {
+                account: "assets:cash".to_string(),
+                amount: 100.00,
+            },
+            Account {
+                account: "expenses:foo".to_string(),
+                amount: 0.00,
+            },
+        ],
+        transactions: vec![
+            Transaction {
+                date: "2020-01-01".to_string(),
+                account: Some("assets:cash".to_string()),
+                amount: Some(10.00),
+                description: "summary_transaction".to_string(),
+                offset_account: Some("expenses:foo".to_string()),
+                transactions: None,
+            },
+            Transaction {
+                date: "2020-01-01".to_string(),
+                account: None,
+                amount: None,
+                description: "detailed_transaction".to_string(),
+                offset_account: None,
+                transactions: Some(vec![
+                    TransactionList {
+                        account: "assets:cash".to_string(),
+                        amount: -50.00,
+                    },
+                    TransactionList {
+                        account: "expenses:bar".to_string(),
+                        amount: 20.00,
+                    },
+                    TransactionList {
+                        account: "expenses:baz".to_string(),
+                        amount: 30.00,
+                    },
+                ]),
+            },
+        ],
+    };
+
+    let result = flatten_transactions(file);
+    assert_eq!(result.len(), 5)
 }


### PR DESCRIPTION
`group` commands are passed in via `-g` parameter.

This PR includes the prerequisite groundwork and refactoring for implementing the budget/actual functionality. The original ledger allows users to group register output by a specific time period for budget/actual reporting, so I thought it would be easiest to start there first. 

This also includes a couple of bonus additions and in some cases, deletions:
- reassigned `-f` as ledger file parameter and `-o` for option for better mnemonics. 
- reorganization of structs and their related methods. The new methods are covered by tests.
- flattens overall deserialized `LedgerFile` data structure before sending downstream.
- consolidation of logic as a result of `LedgerFile` flattening. This did result in some changes to the `register` output format, but I will be adjusting it over time to eventually align with the standard "general ledger" format that ledger uses.
- update date format to be `YYYY-MM-DD`.
- implement `chrono` library to handle date types. This will allow for more robust date functionality going forward, such as parsing, printing and sorting.
- README updates

Testing:
- `cargo run rust_ledger -f ./examples/example.yaml register -o expense -g month`
- verify the output:
```
Date       Total                   
---------------------------------------------------------------------------------
2019-12    $ 455.00               
2020-01    $ 3200.00         
```
- substituting `year` for the `-g` param will yield:
```
Date       Total                   
---------------------------------------------------------------------------------
2019       $ 455.00               
2020       $ 3200.00                
```