### PR TITLE
Restructure CSV logic

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,17 +1,69 @@
 name: rust_ledger
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+on: [push, pull_request]
 
 jobs:
-  build:
+  check:
+    name: Check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  lints:
+    name: Lints
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/README.md
+++ b/README.md
@@ -56,9 +56,11 @@ export RLEDGER_FILE="$HOME/rledger.yaml"
 
 COMMAND - ledger command (account, balance, register, or csv)
 
-OPTION (denoted by `-o`) - allows you to filter the output of the `register` command by account type. For example, if you wish to only see "expense" transactions in the output, you would pass in `expense` as the option here.
+OPTION (denoted by `-o`) - allows you to filter the output of the `register` command by account type. For example, if you wish to only see "expense" transactions in the output, you would pass in `expense` as the option here. Additionally, the csv tool uses this parameter for specifying the csv file to be parsed.
 
 GROUP (denoted by `-g`) - allows you to group the output of the `register` command by `year` or `month`. 
+
+OFFSET (denoted by `-s`) - required for csv tool. Specifies the offsetting account that each transaction should be posted against. 
 
 ### Environment Variables
 
@@ -168,10 +170,15 @@ Date       Description             Accounts
 ```
 
 - csv
-  - converts `csv` files to `yaml` format expected by `rust_ledger`
-  - most financial institutions (banks, credit unions and credit card companies) will provide exports of transaction history in `csv` format
+  - converts `csv` files to `yaml` format expected by `rust_ledger`.
+  - should be invoked with `-f`, `-o`, and `s` arguments. These include the rust_ledger file location (unless specified via environment variable),
+  csv file location and account offset, respectively.
+  - the account offset (`s` argument) would be the offset transaction that the csv transactions should be posted against.
+  - the csv tool will look for existing transactions that have matching `description` fields and will populate the appropriate expense/income accounts
+  for any matches. Non-matches will use a default of `expense:general` or `income:general`, which is determined based on the sign of the `amount` field
+  contained in the transaction.
   - **note** - prior to importing your `csv` file into the tool, you must rename the columns in the first line of the `csv` file in the following schema:
-    `"date","transaction","name","memo","amount"`
+    `"date","transaction","name","memo","amount"`.
 
 ### rust_ledger `yaml` file format
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,46 +5,54 @@ mod register;
 
 use crate::error::{Error, Result};
 use crate::model::ledger::Group;
-use pargs;
+use pargs::*;
 use std::env;
 
 pub fn run() -> Result<()> {
     let args: Vec<String> = env::args().collect();
 
     // define expected args for pargs
-    let command_args: Vec<String> = vec![
+    let expected_command_args: Vec<String> = vec![
         String::from("account"),
         String::from("balance"),
         String::from("register"),
         String::from("csv"),
     ];
-    let flag_args: Vec<String> = vec![];
-    let option_args: Vec<String> = vec![String::from("-f"), String::from("-o"), String::from("-g")];
+    let expected_flag_args: Vec<String> = vec![];
+    let expected_option_args: Vec<String> = vec![
+        String::from("-f"),
+        String::from("-o"),
+        String::from("-g"),
+        String::from("-s"),
+    ];
 
-    // pargs will parse the args and return the result
-    let pargs_result = pargs::parse(args, command_args, flag_args, option_args)?;
+    let Matches {
+        command_args,
+        option_args,
+        ..
+    } = pargs::parse(
+        args,
+        expected_command_args,
+        expected_flag_args,
+        expected_option_args,
+    )?;
 
-    let pargs_options = pargs_result.option_args;
-    let pargs_commands = pargs_result.command_args;
-
-    let ledger_file = match pargs_options.get("-f") {
-        Some(value) => value.to_string(),
-        None => {
-            let ledger_file_env = match std::env::var("RLEDGER_FILE") {
-                Ok(p) => format!("{}", p),
-                Err(err) => format!("{}", err),
-            };
-
-            ledger_file_env.to_string()
-        }
+    let ledger_file_env = match std::env::var("RLEDGER_FILE") {
+        Ok(p) => p,
+        Err(err) => format!("{}", err),
     };
 
-    let options_arg = match pargs_options.get("-o") {
-        Some(value) => value,
-        None => "",
+    let ledger_file = match option_args.get("-f") {
+        Some(value) => value.as_str(),
+        None => ledger_file_env.as_str(),
     };
 
-    let group_arg = match pargs_options.get("-g") {
+    let options_arg = match option_args.get("-o") {
+        Some(value) => String::from(value),
+        None => String::from(""),
+    };
+
+    let group_arg = match option_args.get("-g") {
         Some(value) => match value.as_str() {
             "month" => Group::Month,
             "year" => Group::Year,
@@ -53,18 +61,19 @@ pub fn run() -> Result<()> {
         None => Group::None,
     };
 
-    match &pargs_commands.len() {
-        0 => Err(Error::InvalidArg("please enter a command.".to_string())),
-        _ => match &pargs_commands[0][..] {
-            "account" => account::account(&ledger_file.to_string()),
-            "balance" => balance::balance(&ledger_file.to_string()),
-            "register" => register::register(
-                &ledger_file.to_string(),
-                &options_arg.to_string(),
-                group_arg,
-            ),
-            "csv" => csv::csv(&ledger_file.to_string(), &options_arg.to_string()),
-            _ => panic!("command not found.".to_string()),
+    let offset_arg = match option_args.get("-s") {
+        Some(value) => String::from(value),
+        None => String::from(""),
+    };
+
+    match &command_args.len() {
+        0 => Err(Error::InvalidArg(String::from("please enter a command."))),
+        _ => match &command_args[0][..] {
+            "account" => account::account(ledger_file),
+            "balance" => balance::balance(ledger_file),
+            "register" => register::register(ledger_file, &options_arg, group_arg),
+            "csv" => csv::csv(ledger_file, &options_arg, &offset_arg),
+            _ => panic!("command not found."),
         },
     }
 }

--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -4,7 +4,7 @@ use crate::error::Result;
 use crate::model::ledger::LedgerFile;
 
 /// returns all general ledger accounts
-pub fn account(filename: &String) -> Result<()> {
+pub fn account(filename: &str) -> Result<()> {
     let file = std::fs::File::open(filename)?;
     let deserialized_file: LedgerFile = serde_yaml::from_reader(file).unwrap();
 

--- a/src/cli/balance.rs
+++ b/src/cli/balance.rs
@@ -4,7 +4,7 @@ use crate::error::Result;
 use crate::model::ledger::LedgerFile;
 
 /// returns balances of all general ledger accounts
-pub fn balance(filename: &String) -> Result<()> {
+pub fn balance(filename: &str) -> Result<()> {
     let file = std::fs::File::open(filename)?;
     let deserialized_file: LedgerFile = serde_yaml::from_reader(file).unwrap();
 

--- a/src/cli/csv.rs
+++ b/src/cli/csv.rs
@@ -3,9 +3,12 @@ extern crate csv;
 use crate::error::Error;
 use crate::model::ledger::LedgerFile;
 use serde::{Deserialize, Serialize};
-use std::{fs, io::Write};
+use std::{
+    fs,
+    io::{stdout, Write},
+};
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 struct CSV {
     date: String,
     transaction: String,
@@ -13,8 +16,33 @@ struct CSV {
     amount: f64,
 }
 
+impl CSV {
+    fn match_account(self, ledger_file: &LedgerFile) -> String {
+        for match_item in ledger_file.clone().transactions {
+            let account = match &match_item.account {
+                None => "".to_string(),
+                Some(name) => name.to_string(),
+            };
+
+            if match_item.description == self.name {
+                return account;
+            }
+
+            if self.amount.is_sign_negative() {
+                return "expense:general".to_string();
+            }
+        }
+        "income:general".to_string()
+    }
+}
+
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 struct CSVOutput {
+    records: Vec<CSVRecord>,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct CSVRecord {
     date: String,
     amount: f64,
     account: String,
@@ -22,45 +50,38 @@ struct CSVOutput {
     description: String,
 }
 
-struct CSVMatches {
-    account: String,
-    description: String,
-}
-
-fn write<T>(writer: &mut T, csv_output: &[CSVOutput]) -> Result<(), serde_yaml::Error>
-where
-    T: Write,
-{
-    serde_yaml::to_writer(writer, csv_output)?;
-    Ok(())
-}
-
-fn write_ledger_file(
-    ledger_file: &String,
-    csv_output: &[CSVOutput],
-) -> Result<(), serde_yaml::Error> {
-    let mut f = fs::OpenOptions::new()
-        .append(true)
-        .open(ledger_file)
-        .unwrap();
-    write(&mut f, csv_output)
-}
-
-fn insert_match_acct(csv_matches: &[CSVMatches], record: &CSV) -> String {
-    for match_item in csv_matches {
-        if match_item.description == record.name {
-            return match_item.account.to_string();
+impl CSVOutput {
+    fn new() -> CSVOutput {
+        CSVOutput {
+            records: Vec::new(),
         }
     }
-    if record.amount < 1.0 {
-        "expense:general".to_string()
-    } else {
-        "income:general".to_string()
+
+    fn write<T>(&self, writer: &mut T) -> Result<(), serde_yaml::Error>
+    where
+        T: Write,
+    {
+        serde_yaml::to_writer(writer, self)?;
+        Ok(())
+    }
+
+    fn write_to_stdout(self) -> Result<(), serde_yaml::Error> {
+        CSVOutput::write(&self, &mut stdout())
+    }
+
+    fn populate_output_vec(&mut self, record: CSV, account: String, offset: &str) {
+        self.records.push(CSVRecord {
+            date: record.date,
+            amount: -record.amount as f64,
+            account,
+            offset_account: offset.to_string(),
+            description: record.name.trim().to_string(),
+        })
     }
 }
 
 /// convert csv to yaml format
-pub fn csv(ledger_file: &String, csv_file: &String) -> Result<(), Error> {
+pub fn csv(ledger_file: &str, csv_file: &str, offset: &str) -> Result<(), Error> {
     // open csv file
     let raw_csv_file = fs::File::open(csv_file)?;
     let mut csv_reader = csv::Reader::from_reader(raw_csv_file);
@@ -69,55 +90,197 @@ pub fn csv(ledger_file: &String, csv_file: &String) -> Result<(), Error> {
     let raw_ledger_file = std::fs::File::open(ledger_file)?;
     let deserialized_file: LedgerFile = serde_yaml::from_reader(raw_ledger_file).unwrap();
 
-    let mut csv_output: Vec<CSVOutput> = Vec::new();
-    let mut csv_matches: Vec<CSVMatches> = Vec::new();
+    let mut csv_output = CSVOutput::new();
 
     for result in csv_reader.deserialize() {
         let record: CSV = result?;
 
-        // loop through transactions and find matching memos
-        for transaction in &deserialized_file.transactions {
-            let optional_account = match &transaction.account {
-                None => "".to_string(),
-                Some(name) => name.to_string(),
-            };
+        let account = CSV::match_account(record.clone(), &deserialized_file);
 
-            if transaction.description.trim() == record.name.trim() {
-                csv_matches.push(CSVMatches {
-                    account: optional_account.to_string(),
-                    description: transaction.description.trim().to_string(),
-                })
-            }
-        }
-        // match memos with existing accounts in ledger yaml file
-        let matched_acct_name = insert_match_acct(&csv_matches, &record);
-        // push transaction to csv output Vector
-
-        // if amount is negative, post as expense
-        if record.amount < 1.0 {
-            csv_output.push(CSVOutput {
-                date: record.date,
-                amount: -record.amount as f64,
-                account: matched_acct_name,
-                offset_account: "credit_card".to_string(),
-                description: record.name.trim().to_string(),
-            })
-        } else {
-            // if amount is positive, post as income
-            csv_output.push(CSVOutput {
-                date: record.date,
-                amount: record.amount as f64,
-                account: matched_acct_name,
-                offset_account: "credit_card".to_string(),
-                description: record.name.trim().to_string(),
-            })
-        }
+        csv_output.populate_output_vec(record, account, offset);
     }
 
-    // write csv_output contents to ledger file
-    write_ledger_file(ledger_file, &csv_output).unwrap();
-
-    println!("contents of csv file successfully applied to ledger yaml file");
+    // write csv_output contents to stdout
+    CSVOutput::write_to_stdout(csv_output).unwrap();
 
     Ok(())
+}
+
+#[cfg(test)]
+fn get_file() -> LedgerFile {
+    use crate::model::ledger::{Account, Transaction, TransactionList};
+    use chrono::NaiveDate;
+
+    let date = match NaiveDate::parse_from_str("2020-01-01", "%Y-%m-%d") {
+        Ok(d) => d,
+        Err(e) => panic!("{:?}", e),
+    };
+
+    return LedgerFile {
+        accounts: vec![
+            Account {
+                account: "asset:cash".to_string(),
+                amount: 100.00,
+            },
+            Account {
+                account: "expense:foo".to_string(),
+                amount: 0.00,
+            },
+            Account {
+                account: "expense:bar".to_string(),
+                amount: 0.00,
+            },
+            Account {
+                account: "expense:baz".to_string(),
+                amount: 0.00,
+            },
+        ],
+        transactions: vec![
+            Transaction {
+                date,
+                account: Some("asset:cash".to_string()),
+                amount: Some(10.00),
+                description: "summary_transaction".to_string(),
+                offset_account: Some("expense:foo".to_string()),
+                transactions: None,
+            },
+            Transaction {
+                date,
+                account: Some("asset:cash".to_string()),
+                amount: Some(-42.00),
+                description: "summary_transaction".to_string(),
+                offset_account: Some("expense:foo".to_string()),
+                transactions: None,
+            },
+            Transaction {
+                date,
+                account: None,
+                amount: None,
+                description: "detailed_transaction".to_string(),
+                offset_account: None,
+                transactions: Some(vec![
+                    TransactionList {
+                        account: "asset:cash".to_string(),
+                        amount: -50.00,
+                    },
+                    TransactionList {
+                        account: "expense:bar".to_string(),
+                        amount: 20.00,
+                    },
+                    TransactionList {
+                        account: "expense:baz".to_string(),
+                        amount: 30.00,
+                    },
+                ]),
+            },
+        ],
+    };
+}
+
+/// negative `amount`s that do not have `name` matches should
+/// be expense:general
+#[test]
+fn account_should_be_expense_general() {
+    let file = get_file();
+    let record = CSV {
+        date: "2020-01-01".to_string(),
+        transaction: "twin peaks diner coffee".to_string(),
+        name: "coffee".to_string(),
+        amount: -2.50,
+    };
+
+    let result = CSV::match_account(record, &file);
+
+    assert_eq!(result, "expense:general");
+}
+
+/// positive `amount`s that do not have `name` matches should
+/// be income:general
+#[test]
+fn account_should_be_income_general() {
+    let file = get_file();
+    let record = CSV {
+        date: "2020-01-01".to_string(),
+        transaction: "donuts sold to dale cooper".to_string(),
+        name: "donuts".to_string(),
+        amount: 2.50,
+    };
+
+    let result = CSV::match_account(record, &file);
+
+    assert_eq!(result, "income:general");
+}
+
+/// `name` matches should use the matched account `name`
+#[test]
+fn account_should_be_matched_account() {
+    let file = get_file();
+    let record = CSV {
+        date: "2020-01-01".to_string(),
+        transaction: "cherry pie sold to dale cooper".to_string(),
+        name: "summary_transaction".to_string(),
+        amount: 2.50,
+    };
+
+    let result = CSV::match_account(record, &file);
+
+    assert_eq!(result, "asset:cash");
+}
+
+/// negative `amount` should be expressed as debit
+#[test]
+fn negative_csv_amount_should_be_debit() {
+    let mut csv_output = CSVOutput::new();
+    let account = "expense:general".to_string();
+    let offset = "liability:amex".to_string();
+    let record = CSV {
+        date: "2020-01-01".to_string(),
+        transaction: "twin peaks diner coffee".to_string(),
+        name: "coffee".to_string(),
+        amount: -2.50,
+    };
+
+    csv_output.populate_output_vec(record.clone(), account.clone(), &offset);
+
+    let mut expected = CSVOutput {
+        records: Vec::new(),
+    };
+    expected.records.push(CSVRecord {
+        date: record.date,
+        amount: -record.amount as f64,
+        account,
+        offset_account: offset.to_string(),
+        description: record.name.trim().to_string(),
+    });
+
+    assert_eq!(csv_output, expected);
+}
+
+/// positive `amount` should be expressed as credit
+#[test]
+fn positive_csv_amount_should_be_credit() {
+    let mut csv_output = CSVOutput::new();
+    let account = "income:general".to_string();
+    let offset = "asset:cash".to_string();
+    let record = CSV {
+        date: "2020-01-01".to_string(),
+        transaction: "coffee sold to dale cooper".to_string(),
+        name: "coffee".to_string(),
+        amount: 2.50,
+    };
+
+    csv_output.populate_output_vec(record.clone(), account.clone(), &offset);
+
+    let mut expected = CSVOutput {
+        records: Vec::new(),
+    };
+    expected.records.push(CSVRecord {
+        date: record.date,
+        amount: -record.amount as f64,
+        account,
+        offset_account: offset.to_string(),
+        description: record.name.trim().to_string(),
+    });
+
+    assert_eq!(csv_output, expected);
 }

--- a/src/cli/register.rs
+++ b/src/cli/register.rs
@@ -4,7 +4,7 @@ use crate::error::Result;
 use crate::model::ledger::{Group, LedgerFile};
 
 /// returns all general ledger transactions
-pub fn register(filename: &String, option: &String, group: Group) -> Result<()> {
+pub fn register(filename: &str, option: &str, group: Group) -> Result<()> {
     let file = std::fs::File::open(filename)?;
     let deserialized_file: LedgerFile = serde_yaml::from_reader(file).unwrap();
 


### PR DESCRIPTION
- arranged CSV logic into structs and related methods. This greatly improves readability as I was able to consolidate a lot of things together. The feature itself remains largely unchanged, with the exception of the following:
   - the csv output is now directed to `stdout` rather than writing to the ledger file. This change maintains parity with `ledger`.
   - offset accounts should be specified using `-s` argument. 
- updated github actions to use `clippy` and `rustfmt`.
   - this PR includes changes related to clippy comments. I have never run clippy locally before, so I fixed up the errors it returned. Most of the errors were related to unnecessary return statements, using `String` over `&str`, using `print!()` instead of `println!()`, etc.
- updated readme