### PR TITLE
bugfix: don't panic wihout command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,6 +29,6 @@ pub fn run() -> Result<()> {
             options_arg.as_str(),
             offset_arg.as_str(),
         ),
-        Command::None => panic!("command not found"),
+        Command::None => unreachable!(),
     }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,6 +1,6 @@
 extern crate clap;
 use crate::model::ledger::Group;
-use clap::{crate_version, App, Arg, ArgMatches, SubCommand};
+use clap::{crate_version, App, AppSettings, Arg, ArgMatches, SubCommand};
 
 pub struct Args {
     pub ledger_file: String,
@@ -43,6 +43,7 @@ impl Args {
         let matches = App::new("rust_ledger")
             .version(crate_version!())
             .author("Eric Crowder <eric@ebcrowder.dev>")
+            .setting(AppSettings::ArgRequiredElseHelp)
             .subcommand(
                 SubCommand::with_name("account")
                     .about("account module")


### PR DESCRIPTION
Hi!
I think it will be better to see help message instead of panic when you forgot to specify command.
After this fix you will see something like that:
```bash
$ cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.12s
     Running `target/debug/rust_ledger`
rust_ledger 0.4.3
Eric Crowder <eric@ebcrowder.dev>

USAGE:
    rust_ledger [SUBCOMMAND]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

SUBCOMMANDS:
    account     account module
    balance     balance module
    csv         csv module
    help        Prints this message or the help of the given subcommand(s)
    register    register module
$ 

```